### PR TITLE
Fix Smarty fatal error by processing basename in PHP

### DIFF
--- a/plugins/generic/reviewerCertificate/ReviewerCertificatePlugin.inc.php
+++ b/plugins/generic/reviewerCertificate/ReviewerCertificatePlugin.inc.php
@@ -32,9 +32,6 @@ class ReviewerCertificatePlugin extends GenericPlugin {
             HookRegistry::register('LoadHandler', array($this, 'setupHandler'));
             HookRegistry::register('TemplateManager::display', array($this, 'addCertificateButton'));
             HookRegistry::register('reviewassignmentdao::_updateobject', array($this, 'handleReviewComplete'));
-
-            // Register custom Smarty modifiers to avoid deprecation warnings
-            HookRegistry::register('TemplateManager::fetch', array($this, 'registerSmartyModifiers'));
         }
 
         return $success;
@@ -119,29 +116,6 @@ class ReviewerCertificatePlugin extends GenericPlugin {
             define('HANDLER_CLASS', 'CertificateHandler');
             return true;
         }
-
-        return false;
-    }
-
-    /**
-     * Register custom Smarty modifiers
-     */
-    public function registerSmartyModifiers($hookName, $params) {
-        $templateMgr = $params[0];
-        $smarty = $templateMgr->getSmarty();
-
-        // Register basename modifier
-        $smarty->registerPlugin('modifier', 'basename', function($path) {
-            return basename($path);
-        });
-
-        // Register date modifier
-        $smarty->registerPlugin('modifier', 'date', function($timestamp, $format = 'Y-m-d H:i:s') {
-            if (is_numeric($timestamp)) {
-                return date($format, $timestamp);
-            }
-            return date($format, strtotime($timestamp));
-        });
 
         return false;
     }

--- a/plugins/generic/reviewerCertificate/classes/form/CertificateSettingsForm.inc.php
+++ b/plugins/generic/reviewerCertificate/classes/form/CertificateSettingsForm.inc.php
@@ -165,6 +165,12 @@ class CertificateSettingsForm extends Form {
 
         $templateMgr->assign('defaultBodyTemplate', $defaultBodyTemplate);
 
+        // Assign background image filename separately to avoid Smarty modifier deprecation
+        $backgroundImage = $this->getData('backgroundImage');
+        if ($backgroundImage) {
+            $templateMgr->assign('backgroundImageName', basename($backgroundImage));
+        }
+
         return parent::fetch($request, $template, $display);
     }
 

--- a/plugins/generic/reviewerCertificate/templates/certificateSettings.tpl
+++ b/plugins/generic/reviewerCertificate/templates/certificateSettings.tpl
@@ -26,7 +26,7 @@
 		{fbvFormSection title="plugins.generic.reviewerCertificate.settings.backgroundImage" description="plugins.generic.reviewerCertificate.settings.backgroundImageDescription"}
 			<input type="file" id="backgroundImage" name="backgroundImage" accept="image/*" class="pkp_form_file" />
 			{if $backgroundImage}
-				<p class="description">{translate key="plugins.generic.reviewerCertificate.settings.currentImage"}: {$backgroundImage|basename}</p>
+				<p class="description">{translate key="plugins.generic.reviewerCertificate.settings.currentImage"}: {$backgroundImageName}</p>
 			{/if}
 		{/fbvFormSection}
 


### PR DESCRIPTION
This commit fixes the fatal error:
"Smarty: undefined extension class 'Smarty_Internal_Method_GetSmarty'"

The previous approach of registering Smarty modifiers using getSmarty() was incompatible with this version of OJS/Smarty. Instead, we now:

1. Process basename() in PHP within CertificateSettingsForm::fetch()
2. Assign the processed filename as $backgroundImageName to the template
3. Update the template to use $backgroundImageName instead of the {$backgroundImage|basename} modifier
4. Remove the registerSmartyModifiers() method and hook registration

This approach is cleaner, more maintainable, and avoids Smarty compatibility issues across different OJS versions.

Changes:
- Removed TemplateManager::fetch hook registration
- Removed registerSmartyModifiers() method
- Added backgroundImageName assignment in CertificateSettingsForm
- Updated certificateSettings.tpl to use $backgroundImageName

Fixes:
- PHP Fatal error: Smarty: undefined extension class 'Smarty_Internal_Method_GetSmarty'
- PHP Deprecated: Using php-function "basename" as a modifier