### PR TITLE
Fix TCPDF library path to use absolute path

### DIFF
--- a/classes/CertificateGenerator.inc.php
+++ b/classes/CertificateGenerator.inc.php
@@ -11,7 +11,8 @@
  * @brief Generates PDF certificates for reviewers
  */
 
-require_once('lib/pkp/lib/vendor/tecnickcom/tcpdf/tcpdf.php');
+// Load TCPDF library using absolute path
+require_once(Core::getBaseDir() . '/lib/pkp/lib/vendor/tecnickcom/tcpdf/tcpdf.php');
 
 class CertificateGenerator {
 


### PR DESCRIPTION
This commit fixes a critical error where the TCPDF library could not be loaded due to an incorrect relative path.

Error fixed:
- PHP Fatal error: Failed opening required 'lib/pkp/lib/vendor/tecnickcom/tcpdf/tcpdf.php'
- PHP Warning: require_once(lib/pkp/lib/vendor/tecnickcom/tcpdf/tcpdf.php): Failed to open stream

Changes:
- Changed from relative path to absolute path using Core::getBaseDir()
- Path: Core::getBaseDir() . '/lib/pkp/lib/vendor/tecnickcom/tcpdf/tcpdf.php'

This ensures the TCPDF library is loaded correctly regardless of where the plugin is called from, fixing the certificate preview and generation functionality.