### PR TITLE
Fix certificate preview errors

### DIFF
--- a/classes/CertificateGenerator.inc.php
+++ b/classes/CertificateGenerator.inc.php
@@ -247,16 +247,17 @@ class CertificateGenerator {
      * @param $pdf TCPDF
      */
     private function addQRCode($pdf) {
-        $request = Application::get()->getRequest();
-
         // Determine verification URL
         if ($this->previewMode) {
-            // Use sample URL for preview
-            $verificationUrl = $request->url(null, 'certificate', 'verify', 'PREVIEW12345');
+            // Use sample URL for preview - don't call url() in preview mode to avoid router errors
+            $request = Application::get()->getRequest();
+            $baseUrl = $request->getBaseUrl();
+            $verificationUrl = $baseUrl . '/index.php/index/certificate/verify/PREVIEW12345';
         } else {
             if (!$this->certificate) {
                 return;
             }
+            $request = Application::get()->getRequest();
             $verificationUrl = $request->url(null, 'certificate', 'verify', $this->certificate->getCertificateCode());
         }
 
@@ -377,11 +378,11 @@ class CertificateGenerator {
      * @return string
      */
     private function getDefaultBodyTemplate() {
-        return "This certificate is awarded to\n\n" .
-               "{{$reviewerName}}\n\n" .
-               "In recognition of their valuable contribution as a peer reviewer for\n\n" .
-               "{{$journalName}}\n\n" .
-               "Review completed on {{$reviewDate}}\n\n" .
-               "Manuscript: {{$submissionTitle}}";
+        return 'This certificate is awarded to' . "\n\n" .
+               '{{$reviewerName}}' . "\n\n" .
+               'In recognition of their valuable contribution as a peer reviewer for' . "\n\n" .
+               '{{$journalName}}' . "\n\n" .
+               'Review completed on {{$reviewDate}}' . "\n\n" .
+               'Manuscript: {{$submissionTitle}}';
     }
 }


### PR DESCRIPTION
This commit fixes two critical errors that prevented certificate preview from working:

1. Fixed undefined variable warnings in getDefaultBodyTemplate() Error: "Undefined variable $reviewerName, $journalName, etc." Cause: Double quotes in template string caused PHP to interpret {{$var}} as variables Fix: Changed to single quotes to prevent variable interpolation

2. Fixed QR code URL generation fatal error in preview mode Error: "Path must be null when calling PKPComponentRouter::url()" Cause: url() method called during preview which uses ComponentRouter context Fix: Use simple URL construction for preview mode instead of url() method

Changes:
- getDefaultBodyTemplate(): Use single quotes for template variables
- addQRCode(): Build preview URL directly using getBaseUrl() instead of url()

The preview certificate functionality now works without errors!

Fixes:
- PHP Warning: Undefined variable $reviewerName
- PHP Warning: Undefined variable $journalName
- PHP Warning: Undefined variable $reviewDate
- PHP Warning: Undefined variable $submissionTitle
- PHP Fatal error: Path must be null when calling PKPComponentRouter::url()