### PR TITLE
Fix critical PHP parse error preventing plugin installation

### DIFF
--- a/ReviewerCertificatePlugin.inc.php
+++ b/ReviewerCertificatePlugin.inc.php
@@ -418,9 +418,6 @@ class ReviewerCertificatePlugin extends GenericPlugin {
             $reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
             $reviewAssignments = $reviewAssignmentDao->getBySubmissionId($templateVar->getId());
 
-            // Log the type for debugging
-                     (is_array($reviewAssignments) ? ' with ' . count($reviewAssignments) . ' items' : ''));
-
             // Find the review assignment for the current user
             // Handle both DAOResultFactory (object with next()) and array return types
             if ($reviewAssignments) {


### PR DESCRIPTION
Error: Unclosed '{' on line 408 does not match ')' on line 422

Issue: Line 422 contained an incomplete code fragment left over from debug logging removal - a dangling ternary operator with parentheses but no function call or assignment.

Fix: Removed the incomplete statement on line 422.

The fragment was:
    (is_array($reviewAssignments) ? ' with ' . count($reviewAssignments) . ' items' : ''));

This was causing a fatal PHP parse error that prevented the plugin from being installed or enabled in OJS.

Verified: php -l confirms no syntax errors in all PHP files.