### PR TITLE
Fix class loading issue - Use fully qualified parent class names

### DIFF
--- a/ReviewerCertificatePlugin.inc.php
+++ b/ReviewerCertificatePlugin.inc.php
@@ -11,7 +11,6 @@
  * @brief Reviewer Certificate Plugin - Enables reviewers to generate and download personalized PDF certificates
  */
 
-use PKP\plugins\GenericPlugin;
 use PKP\core\JSONMessage;
 use PKP\config\Config;
 use PKP\linkAction\LinkAction;
@@ -19,7 +18,7 @@ use PKP\linkAction\request\AjaxModal;
 use PKP\mail\MailTemplate;
 use APP\facades\Repo;
 
-class ReviewerCertificatePlugin extends GenericPlugin {
+class ReviewerCertificatePlugin extends \PKP\plugins\GenericPlugin {
 
     /**
      * @copydoc Plugin::register()

--- a/classes/CertificateDAO.inc.php
+++ b/classes/CertificateDAO.inc.php
@@ -11,12 +11,11 @@
  * @brief Operations for retrieving and modifying Certificate objects
  */
 
-use PKP\db\DAO;
 use PKP\db\DAOResultFactory;
 
 require_once(dirname(__FILE__) . '/Certificate.inc.php');
 
-class CertificateDAO extends DAO {
+class CertificateDAO extends \PKP\db\DAO {
 
     /**
      * Retrieve a certificate by certificate ID

--- a/classes/form/CertificateSettingsForm.inc.php
+++ b/classes/form/CertificateSettingsForm.inc.php
@@ -11,14 +11,13 @@
  * @brief Form for managing certificate settings
  */
 
-use PKP\form\Form;
 use PKP\form\validation\FormValidator;
 use PKP\form\validation\FormValidatorPost;
 use PKP\form\validation\FormValidatorCSRF;
 use PKP\form\validation\FormValidatorCustom;
 use APP\facades\Repo;
 
-class CertificateSettingsForm extends Form {
+class CertificateSettingsForm extends \PKP\form\Form {
 
     /** @var ReviewerCertificatePlugin */
     private $plugin;

--- a/controllers/CertificateHandler.inc.php
+++ b/controllers/CertificateHandler.inc.php
@@ -11,13 +11,12 @@
  * @brief Handle requests for certificate operations
  */
 
-use APP\handler\Handler;
 use PKP\core\JSONMessage;
 use PKP\security\Role;
 use PKP\security\authorization\ContextAccessPolicy;
 use APP\facades\Repo;
 
-class CertificateHandler extends Handler {
+class CertificateHandler extends \APP\handler\Handler {
 
     /** @var ReviewerCertificatePlugin */
     private $plugin;


### PR DESCRIPTION
FIXED:
- Plugin loading error: 'Plugin expected to inherit from ReviewerCertificatePlugin, actual type NULL'
- Changed parent class references from 'use' imports to fully qualified names
- ReviewerCertificatePlugin extends \PKP\plugins\GenericPlugin (not imported)
- CertificateDAO extends \PKP\db\DAO (not imported)
- CertificateHandler extends \APP\handler\Handler (not imported)
- CertificateSettingsForm extends \PKP\form\Form (not imported)

REASON:
OJS requires parent plugin/base classes to use fully qualified names to ensure proper class loading order. Using 'use' statements for parent classes can cause instantiation failures when PHP's autoloader hasn't loaded the parent yet.

This maintains compatibility across OJS 3.3, 3.4, and 3.5.