### PR TITLE
Fix certificate font size not being applied to PDF content

### DIFF
--- a/classes/CertificateGenerator.inc.php
+++ b/classes/CertificateGenerator.inc.php
@@ -210,13 +210,20 @@ class CertificateGenerator {
         // Get template variables
         $variables = $this->getTemplateVariables();
 
+        // Get base font size from settings and calculate proportional sizes
+        $baseFontSize = $this->getTemplateSetting('fontSize', 12);
+        $headerSize = round($baseFontSize * 2.0);      // 2x base (default: 24)
+        $bodySize = round($baseFontSize * 1.167);      // 1.167x base (default: 14)
+        $footerSize = round($baseFontSize * 0.833);    // 0.833x base (default: 10)
+        $codeSize = round($baseFontSize * 0.667);      // 0.667x base (default: 8)
+
         // Header text
         $headerText = $this->replaceVariables(
             $this->getTemplateSetting('headerText', 'Certificate of Recognition'),
             $variables
         );
 
-        $pdf->SetFont($pdf->getFontFamily(), 'B', 24);
+        $pdf->SetFont($pdf->getFontFamily(), 'B', $headerSize);
         $pdf->Cell(0, 20, $headerText, 0, 1, 'C');
         $pdf->Ln(10);
 
@@ -226,7 +233,7 @@ class CertificateGenerator {
             $variables
         );
 
-        $pdf->SetFont($pdf->getFontFamily(), '', 14);
+        $pdf->SetFont($pdf->getFontFamily(), '', $bodySize);
         $pdf->MultiCell(0, 10, $bodyTemplate, 0, 'C', 0, 1);
         $pdf->Ln(10);
 
@@ -237,7 +244,7 @@ class CertificateGenerator {
         );
 
         if ($footerText) {
-            $pdf->SetFont($pdf->getFontFamily(), 'I', 10);
+            $pdf->SetFont($pdf->getFontFamily(), 'I', $footerSize);
             $pdf->MultiCell(0, 8, $footerText, 0, 'C', 0, 1);
             $pdf->Ln(5);
         }
@@ -245,7 +252,7 @@ class CertificateGenerator {
         // Certificate code
         if ($this->certificate || $this->previewMode) {
             $code = $this->previewMode ? 'PREVIEW12345' : $this->certificate->getCertificateCode();
-            $pdf->SetFont($pdf->getFontFamily(), '', 8);
+            $pdf->SetFont($pdf->getFontFamily(), '', $codeSize);
             $pdf->Cell(0, 5, 'Certificate Code: ' . $code, 0, 1, 'C');
         }
     }
@@ -289,8 +296,12 @@ class CertificateGenerator {
         );
 
         // Add verification URL text
+        // Use proportional font size for QR code label
+        $baseFontSize = $this->getTemplateSetting('fontSize', 12);
+        $qrLabelSize = round($baseFontSize * 0.5);     // 0.5x base (default: 6)
+
         $pdf->SetXY(150, 282);
-        $pdf->SetFont($pdf->getFontFamily(), '', 6);
+        $pdf->SetFont($pdf->getFontFamily(), '', $qrLabelSize);
         $pdf->Cell(50, 3, 'Scan to verify', 0, 0, 'C');
     }
 

--- a/tests/Unit/CertificateGeneratorTest.php
+++ b/tests/Unit/CertificateGeneratorTest.php
@@ -188,6 +188,44 @@ class CertificateGeneratorTest extends TestCase
     }
 
     /**
+     * Test proportional font size calculations
+     * Ensures that all text elements scale correctly based on the configured base font size
+     */
+    public function testProportionalFontSizes(): void
+    {
+        $testCases = [
+            // [baseFontSize, expectedHeader, expectedBody, expectedFooter, expectedCode, expectedQRLabel]
+            [12, 24, 14, 10, 8, 6],   // Default configuration
+            [16, 32, 19, 13, 11, 8],  // Larger font
+            [10, 20, 12, 8, 7, 5],    // Smaller font
+            [18, 36, 21, 15, 12, 9],  // Very large font
+            [8, 16, 9, 7, 5, 4],      // Very small font
+        ];
+
+        foreach ($testCases as [$base, $expectedHeader, $expectedBody, $expectedFooter, $expectedCode, $expectedQR]) {
+            // Calculate proportional sizes using the same logic as CertificateGenerator
+            $headerSize = round($base * 2.0);      // 2x base
+            $bodySize = round($base * 1.167);      // 1.167x base
+            $footerSize = round($base * 0.833);    // 0.833x base
+            $codeSize = round($base * 0.667);      // 0.667x base
+            $qrLabelSize = round($base * 0.5);     // 0.5x base
+
+            // Verify calculations match expected values
+            $this->assertEquals($expectedHeader, $headerSize, "Header size incorrect for base font $base");
+            $this->assertEquals($expectedBody, $bodySize, "Body size incorrect for base font $base");
+            $this->assertEquals($expectedFooter, $footerSize, "Footer size incorrect for base font $base");
+            $this->assertEquals($expectedCode, $codeSize, "Code size incorrect for base font $base");
+            $this->assertEquals($expectedQR, $qrLabelSize, "QR label size incorrect for base font $base");
+
+            // Verify proportions are maintained
+            $this->assertGreaterThan($bodySize, $headerSize, "Header should be larger than body");
+            $this->assertGreaterThan($footerSize, $bodySize, "Body should be larger than footer");
+            $this->assertGreaterThan($codeSize, $footerSize, "Footer should be larger than code");
+            $this->assertGreaterThan($qrLabelSize, $codeSize, "Code should be larger than QR label");
+        }
+    }
+
+    /**
      * Test QR code URL generation
      */
     public function testQRCodeURL(): void


### PR DESCRIPTION
The fontSize setting was being saved and retrieved correctly but was not being applied to the certificate content. All text elements were using hardcoded font sizes that ignored the user's configuration.

Changes:
- Modified addCertificateContent() to calculate proportional font sizes based on the configured fontSize setting
- Modified addQRCode() to use proportional font size for QR code label
- Font size multipliers:
  * Header: 2.0x base (default 12pt → 24pt)
  * Body: 1.167x base (default 12pt → 14pt)
  * Footer: 0.833x base (default 12pt → 10pt)
  * Certificate Code: 0.667x base (default 12pt → 8pt)
  * QR Label: 0.5x base (default 12pt → 6pt)
- Added comprehensive test testProportionalFontSizes() that validates proportional calculations for various font sizes

Now when users change the fontSize setting, all text elements will scale proportionally, maintaining visual hierarchy while respecting the configured base size.

Fixes issue reported by Dr. Pavlo Nechypurenko.