### PR TITLE
Fix OJS 3.3 compatibility (closes #56)

### DIFF
--- a/classes/Certificate.inc.php
+++ b/classes/Certificate.inc.php
@@ -11,7 +11,15 @@
  * @brief Certificate data model
  */
 
-class Certificate extends \PKP\core\DataObject {
+// OJS 3.3 compatibility: DataObject class alias
+if (class_exists('PKP\core\DataObject')) {
+    class_alias('PKP\core\DataObject', 'CertificateDataObjectBase');
+} else {
+    import('lib.pkp.classes.core.DataObject');
+    class_alias('DataObject', 'CertificateDataObjectBase');
+}
+
+class Certificate extends CertificateDataObjectBase {
 
     /**
      * Get certificate ID
@@ -178,6 +186,12 @@ class Certificate extends \PKP\core\DataObject {
      */
     public function incrementDownloadCount() {
         $this->setDownloadCount($this->getDownloadCount() + 1);
-        $this->setLastDownloaded(\PKP\core\Core::getCurrentDate());
+        // OJS 3.3 compatibility
+        if (class_exists('PKP\core\Core')) {
+            $this->setLastDownloaded(\PKP\core\Core::getCurrentDate());
+        } else {
+            import('lib.pkp.classes.core.Core');
+            $this->setLastDownloaded(Core::getCurrentDate());
+        }
     }
 }

--- a/classes/CertificateDAO.inc.php
+++ b/classes/CertificateDAO.inc.php
@@ -11,11 +11,17 @@
  * @brief Operations for retrieving and modifying Certificate objects
  */
 
-use PKP\db\DAOResultFactory;
-
 require_once(dirname(__FILE__) . '/Certificate.inc.php');
 
-class CertificateDAO extends \PKP\db\DAO {
+// OJS 3.3 compatibility: DAO class alias
+if (class_exists('PKP\db\DAO')) {
+    class_alias('PKP\db\DAO', 'CertificateDAOBase');
+} else {
+    import('lib.pkp.classes.db.DAO');
+    class_alias('DAO', 'CertificateDAOBase');
+}
+
+class CertificateDAO extends CertificateDAOBase {
 
     /**
      * Retrieve a certificate by certificate ID
@@ -80,7 +86,13 @@ class CertificateDAO extends \PKP\db\DAO {
         $sql .= ' ORDER BY date_issued DESC';
 
         $result = $this->retrieve($sql, $params);
-        return new DAOResultFactory($result, $this, '_fromRow');
+        // OJS 3.3 compatibility
+        if (class_exists('PKP\db\DAOResultFactory')) {
+            return new \PKP\db\DAOResultFactory($result, $this, '_fromRow');
+        } else {
+            import('lib.pkp.classes.db.DAOResultFactory');
+            return new DAOResultFactory($result, $this, '_fromRow');
+        }
     }
 
     /**
@@ -94,7 +106,13 @@ class CertificateDAO extends \PKP\db\DAO {
             array((int) $contextId)
         );
 
-        return new DAOResultFactory($result, $this, '_fromRow');
+        // OJS 3.3 compatibility
+        if (class_exists('PKP\db\DAOResultFactory')) {
+            return new \PKP\db\DAOResultFactory($result, $this, '_fromRow');
+        } else {
+            import('lib.pkp.classes.db.DAOResultFactory');
+            return new DAOResultFactory($result, $this, '_fromRow');
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #56 - Plugin breaks OJS 3.3 with error:
```
PHP Fatal error: Uncaught Error: Class "PKP\plugins\GenericPlugin" not found
```

**Root cause**: The plugin uses PHP namespace imports (`use PKP\...`) which only exist in OJS 3.4+. In OJS 3.3, classes are in the global namespace.

## Solution

Added conditional class loading using `class_alias()` that works in both OJS 3.3 (global namespace) and OJS 3.4+ (PKP/APP namespaces).

## Changes

| File | Changes |
|------|---------|
| `ReviewerCertificatePlugin.inc.php` | Class alias for GenericPlugin, JSONMessage helper, LinkAction/AjaxModal/MailTemplate fixes |
| `controllers/CertificateHandler.inc.php` | Class alias for Handler, Role/ContextAccessPolicy/JSONMessage fixes |
| `classes/form/CertificateSettingsForm.inc.php` | Class alias for Form, FormValidator* fixes |
| `classes/CertificateDAO.inc.php` | Class alias for DAO, DAOResultFactory fix |
| `classes/CertificateGenerator.inc.php` | Core::getBaseDir() and Repo facade fixes |
| `classes/Certificate.inc.php` | Class alias for DataObject, Core::getCurrentDate() fix |

## Test plan

- [ ] Install on OJS 3.3.0-x: `php tools/upgrade.php check` should not error
- [ ] Enable plugin and configure settings
- [ ] Download certificate as reviewer
- [ ] Verify still works on OJS 3.4.x and 3.5.x

Tested: PHP syntax passes, locale tests pass (11 tests, 5017 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)