### PR TITLE
Release v1.0.5 - Fix date format and add .po locale files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Reviewer Certificate Plugin for Open Journal Systems (OJS). Generates personalized PDF certificates for peer reviewers after completing reviews. Compatible with OJS 3.3.x, 3.4.x, and 3.5.x.
+
+## Development Commands
+
+```bash
+# Install dependencies
+composer install
+
+# Run all tests
+composer test
+
+# Run specific test suites
+composer test:unit          # Unit tests only
+composer test:integration   # Integration tests only
+composer test:compatibility # OJS version compatibility tests
+composer test:security      # Security tests only
+
+# Run all test suites sequentially
+composer test:all
+
+# Run tests with coverage report
+composer test:coverage
+
+# Run a single test file
+vendor/bin/phpunit tests/Unit/CertificateGeneratorTest.php
+
+# Run a single test method
+vendor/bin/phpunit --filter testGeneratePDF tests/Unit/CertificateGeneratorTest.php
+
+# Check PHP syntax across codebase
+find . -name "*.php" -not -path "./vendor/*" -not -path "./lib/*" -exec php -l {} \;
+```
+
+## Architecture
+
+### Plugin Structure
+
+```
+ReviewerCertificatePlugin.inc.php  # Main plugin entry point
+  ├── Registers hooks: LoadHandler, TemplateManager::display, reviewassignmentdao::_updateobject
+  ├── Manages settings via AJAX modal
+  └── Handles batch certificate generation
+
+controllers/
+  └── CertificateHandler.inc.php   # HTTP request handler
+      ├── download($reviewId)      # Download certificate PDF (requires reviewer role)
+      ├── verify($code)            # Public certificate verification
+      └── generateBatch()          # Batch generation (requires manager role)
+
+classes/
+  ├── Certificate.inc.php          # Data object (certificate record)
+  ├── CertificateDAO.inc.php       # Database operations (extends PKP\db\DAO)
+  ├── CertificateGenerator.inc.php # PDF generation using TCPDF
+  └── form/CertificateSettingsForm.inc.php  # Settings form
+```
+
+### Key Design Decisions
+
+1. **OJS Version Compatibility**: Uses `APP\facades\Repo` for user/submission access (OJS 3.4+) with fallback patterns. Avoid deprecated `import()` function - use PHP namespace imports.
+
+2. **TCPDF Bundled**: Located in `lib/tcpdf/`. The generator tries multiple paths for TCPDF to support different OJS installations.
+
+3. **Database Migration**: Uses Laravel migrations for OJS 3.4+ with automatic SQL fallback for OJS 3.3. Manual SQL in `install.sql`.
+
+4. **Hook-Based Integration**: Certificate button injection uses `TemplateManager::display` hook, checking multiple template patterns for different OJS versions.
+
+### Database Tables
+
+- `reviewer_certificates` - Issued certificate records (links to review_id)
+- `reviewer_certificate_templates` - Per-context template configurations
+- `reviewer_certificate_settings` - Localized template settings
+
+### Template Variables
+
+Available in certificate body template: `{{$reviewerName}}`, `{{$reviewerFirstName}}`, `{{$reviewerLastName}}`, `{{$journalName}}`, `{{$journalAcronym}}`, `{{$submissionTitle}}`, `{{$reviewDate}}`, `{{$reviewYear}}`, `{{$currentDate}}`, `{{$currentYear}}`, `{{$certificateCode}}`
+
+## Testing
+
+Tests use mocked OJS infrastructure (see `tests/mocks/`). Set `OJS_VERSION` env var to test specific versions:
+
+```bash
+OJS_VERSION=3.5 vendor/bin/phpunit --testsuite "Compatibility Tests"
+```
+
+Test structure:
+- `tests/Unit/` - Individual class testing
+- `tests/Integration/` - Workflow testing
+- `tests/Compatibility/` - OJS 3.3/3.4/3.5 specific tests
+- `tests/Security/` - Authorization and input validation
+- `tests/Locale/` - Translation validation (82 keys per language)
+
+## Localization
+
+20 languages in `locale/` directory with dual format support:
+- `.xml` files for OJS 3.3/3.4
+- `.po` files for OJS 3.5+ (required for translations to work)
+
+### Adding New Translations
+
+1. Create new directory (e.g., `locale/fr_FR/`)
+2. Copy both `locale/en_US/locale.xml` and `locale/en_US/locale.po`
+3. Translate all 82 message keys in both files
+4. Update .po header with language code and team
+5. Validate with `php vendor/bin/phpunit tests/Locale/LocaleValidationTest.php`
+
+### Converting XML to PO
+
+Use the conversion script: `php temp/convert_xml_to_po.php`
+
+### PO File Format
+
+```
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Translated Plugin Name"
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,14 +1,37 @@
 # Reviewer Certificate Plugin - Installation Guide
 
-## Quick Install (Recommended)
+## Quick Install via OJS Admin (Recommended)
 
-### Method 1: Automatic Installation via OJS
+The easiest way to install the plugin - no command line needed!
+
+1. **Download** `reviewerCertificate.tar.gz` from [GitHub Releases](https://github.com/ssemerikov/reviewerCertificate/releases)
+
+2. **Log in** to OJS as Administrator
+
+3. **Navigate to** Settings → Website → Plugins
+
+4. **Click** "Upload A New Plugin" button
+
+5. **Select** the downloaded `reviewerCertificate.tar.gz` file
+
+6. **Click** "Save" to upload and install
+
+7. **Enable** the "Reviewer Certificate Plugin"
+
+8. **Click** "Settings" to customize certificate templates
+
+**That's it!** The database tables will be created automatically.
+
+---
+
+## Alternative: Git Clone Installation
+
+For developers or if the tar.gz method doesn't work:
 
 1. **Upload the plugin:**
    ```bash
    cd /path/to/ojs/plugins/generic/
    git clone https://github.com/ssemerikov/reviewerCertificate.git
-   # OR upload and extract the ZIP file
    ```
 
 2. **Set permissions:**
@@ -23,8 +46,6 @@
    - Find "Reviewer Certificate Plugin"
    - Click **Enable**
    - The database tables will be created automatically
-
-   **Note:** The plugin now includes improved database migration with automatic fallback for OJS 3.3 compatibility. If the modern Laravel migration fails, it will automatically retry using raw SQL commands.
 
 4. **Configure:**
    - Click **Settings** to customize certificate templates

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Reviewer Certificate Plugin for OJS
 
-**Version 1.0.2** | [Changelog](CHANGELOG.md) | OJS 3.3+ / 3.4+ / 3.5+
+**Version 1.0.5** | [Changelog](CHANGELOG.md) | OJS 3.3+ / 3.4+ / 3.5+
 
 ## Overview
 
 The Reviewer Certificate Plugin enables reviewers to generate and download personalized PDF certificates of recognition after completing peer reviews. This plugin helps journals acknowledge and incentivize quality peer review work.
 
-**Latest Release (v1.0.2)**: Critical OJS 3.5 compatibility fix - removed all deprecated `import()` function calls. Plugin now works seamlessly with OJS 3.3, 3.4, and 3.5. See [CHANGELOG.md](CHANGELOG.md) for details.
+**Latest Release (v1.0.5)**: Fixed date format display on certificate verification page (PHP 8.1+ compatibility), memory optimization, and missing error handling. See [CHANGELOG.md](CHANGELOG.md) for details.
 
 ## Author
 
@@ -37,10 +37,11 @@ The iterative development approach with Claude Code enabled rapid prototyping, t
 - **QR Code Verification**: Include QR codes for certificate authenticity verification
 - **Download Tracking**: Track certificate downloads and usage statistics
 - **Multi-language Support**: Full internationalization with professional native translations
-  - 19 languages with complete coverage (82 message keys each)
+  - 20 languages with complete coverage (82 message keys each)
   - English, Ukrainian, Russian, Spanish, Portuguese (BR), French, German, Italian, Turkish, Polish, Indonesian, Dutch, Czech, Catalan, Norwegian, Swedish, Croatian, Finnish, Romanian
+  - Dual format support: `.xml` (OJS 3.3/3.4) and `.po` (OJS 3.5) locale files
   - Automatic language detection from OJS settings
-  - All translations validated with comprehensive test suite (5017 assertions)
+  - All translations validated with comprehensive test suite
 - **Batch Generation**: Generate certificates for multiple reviewers at once
 
 ## Requirements
@@ -63,7 +64,21 @@ The iterative development approach with Claude Code enabled rapid prototyping, t
 
 ## Installation
 
-### Quick Install (Recommended)
+### Quick Install via OJS Admin (Recommended)
+
+1. Download `reviewerCertificate.tar.gz` from [Releases](https://github.com/ssemerikov/reviewerCertificate/releases)
+
+2. In OJS, go to **Settings → Website → Plugins**
+
+3. Click **Upload A New Plugin** and select the tar.gz file
+
+4. Click **Enable** on the Reviewer Certificate Plugin
+
+5. Click **Settings** to customize certificate templates
+
+**That's it!** No command line needed.
+
+### Alternative: Git Clone
 
 1. Clone or download the plugin:
    ```bash
@@ -87,7 +102,7 @@ The iterative development approach with Claude Code enabled rapid prototyping, t
    - Click **Settings** to customize certificate templates
    - Click **Preview Certificate** to test your design
 
-**That's it!** The plugin includes TCPDF library, so no additional dependencies need to be installed.
+**Note:** The plugin includes TCPDF library, so no additional dependencies need to be installed.
 
 ### Manual Installation (If Automatic Fails)
 
@@ -175,13 +190,25 @@ We deeply appreciate your expertise and dedication to advancing scholarly commun
 
 ## Language Support
 
-The Reviewer Certificate Plugin is fully internationalized and available in multiple languages:
+The Reviewer Certificate Plugin is fully internationalized and available in multiple languages.
+
+### Locale File Formats
+
+The plugin provides both `.xml` and `.po` locale files for maximum compatibility:
+
+| Format | OJS Version | Location |
+|--------|-------------|----------|
+| `.xml` | 3.3, 3.4 | `locale/{lang}/locale.xml` |
+| `.po` | 3.5+ | `locale/{lang}/locale.po` |
+
+**Note:** OJS 3.5 requires `.po` files for translations to work correctly.
 
 ### Supported Languages
 
 | Language | Locale Code | Native Name | Status |
 |----------|-------------|-------------|--------|
 | English (US) | `en_US` | English | ✅ Complete |
+| English | `en` | English | ✅ Complete |
 | Ukrainian | `uk_UA` | Українська | ✅ Complete |
 | Russian | `ru_RU` | Русский | ✅ Complete |
 | Spanish | `es_ES` | Español | ✅ Complete |
@@ -203,7 +230,7 @@ The Reviewer Certificate Plugin is fully internationalized and available in mult
 
 ### Global Coverage
 
-With 19 languages, the plugin now serves **approximately 85-87% of the global OJS user base** across:
+With 20 languages, the plugin now serves **approximately 85-87% of the global OJS user base** across:
 
 - **Western Europe (7)**: English, French, German, Italian, Spanish, Dutch, Catalan
 - **Nordic Region (3)**: Norwegian (Bokmål), Swedish, Finnish
@@ -231,10 +258,14 @@ All translations feature scholarly terminology appropriate for academic publishi
 
 We welcome community contributions for additional languages! To contribute:
 
-1. Copy `locale/en_US/locale.xml` to a new directory for your language (e.g., `locale/fr_FR/`)
-2. Translate all message strings while preserving template variables (e.g., `{{$reviewerName}}`)
-3. Test your translation with the locale validation tests: `php vendor/bin/phpunit tests/Locale/LocaleValidationTest.php`
-4. Submit a pull request
+1. Create a new directory for your language (e.g., `locale/fr_FR/`)
+2. Copy both `locale/en_US/locale.xml` and `locale/en_US/locale.po` to your new directory
+3. Translate all message strings while preserving template variables (e.g., `{{$reviewerName}}`)
+4. Update the .po file header with your language code and language team
+5. Test your translation with the locale validation tests: `php vendor/bin/phpunit tests/Locale/LocaleValidationTest.php`
+6. Submit a pull request
+
+**Note:** Both `.xml` and `.po` files are required for full OJS compatibility.
 
 **Priority Languages Needed (Tier 3)**: Chinese (Simplified), Arabic, Japanese, Korean, Persian/Farsi, Greek, Hebrew
 
@@ -407,6 +438,25 @@ Copyright (c) 2025 Serhiy O. Semerikov, Academy of Cognitive and Natural Science
 For detailed version history and changes, see [CHANGELOG.md](CHANGELOG.md).
 
 ### Recent Releases
+
+**Version 1.0.5** (2025-01-03)
+- **Fixed**: Date format display on certificate verification page showing `%B %e, %Y` instead of formatted date
+- **Fixed**: PHP 8.1+ compatibility - replaced deprecated `strftime()` with `date()` function
+- **Fixed**: Missing return statement after error in download handler causing potential memory issues
+- Addresses issues reported by Olha P. Pinchuk
+
+**Version 1.0.4** (2025-01-03)
+- **Added**: `.po` locale files for all 20 languages (OJS 3.5 compatibility)
+- **Added**: Brazilian Portuguese translation (community contribution by Pedro Felipe Rocha)
+- **Added**: Simplified installation via tar.gz upload
+- **Improved**: Documentation with user-friendly installation guide
+- Addresses community feedback on PKP Community Forum
+
+**Version 1.0.3** (2025-11-24)
+- **Fixed**: Font size setting not being applied to PDF content
+- **Fixed**: OJS 3.5 redirect() signature compatibility
+- **Fixed**: ReviewAssignmentDAO deprecation in OJS 3.5
+- **Added**: OJS 3.3 namespace compatibility (conditional class loading)
 
 **Version 1.0.2** (2025-11-22)
 - **Fixed**: Critical OJS 3.5 compatibility issue - "Call to undefined function import()" errors

--- a/controllers/CertificateHandler.inc.php
+++ b/controllers/CertificateHandler.inc.php
@@ -145,6 +145,7 @@ class CertificateHandler extends CertificateHandlerBase {
         if (!$reviewAssignment->getDateCompleted()) {
             error_log('Certificate download failed: Review not completed');
             fatalError(__('plugins.generic.reviewerCertificate.error.reviewNotCompleted'));
+            return;
         }
 
         // Get or create certificate
@@ -219,7 +220,9 @@ class CertificateHandler extends CertificateHandlerBase {
                 // Assign valid certificate data to template
                 $templateMgr->assign('isValid', true);
                 $templateMgr->assign('reviewerName', $reviewer->getFullName());
-                $templateMgr->assign('dateIssued', $certificate->getDateIssued());
+                // Format date in PHP to avoid strftime() deprecation issues in PHP 8.1+
+                $formattedDate = date('F j, Y', strtotime($certificate->getDateIssued()));
+                $templateMgr->assign('dateIssued', $formattedDate);
                 $templateMgr->assign('journalName', $context->getLocalizedName());
             } else {
                 // Invalid certificate

--- a/locale/ca_ES/locale.po
+++ b/locale/ca_ES/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Catalan (Spain)\n"
+"Language: ca_ES\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Complement de Certificats de Revisors"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Permet als revisors generar i descarregar certificats PDF personalitzats de reconeixement després de completar les revisions."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Certificat de Revisió"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Certificat de Revisió per Parells"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "El vostre certificat està llest!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Gràcies per completar aquesta revisió. Ara podeu descarregar el vostre certificat de reconeixement."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "El vostre certificat es generarà automàticament quan feu clic al botó de descàrrega."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Descarregar Certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Configuració de Certificats"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Configureu les plantilles de certificats i els criteris d'elegibilitat per als revisors."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Configuració de la Plantilla de Certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Imatge de Fons"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Carregueu una imatge de fons per al certificat (JPG o PNG, mida recomanada: 2100x2970 píxels per A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Imatge de fons actual"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Text de Capçalera"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "El títol principal que es mostra a la part superior del certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "El text de capçalera és obligatori"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Plantilla del Cos del Certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "El contingut principal del certificat. Utilitzeu variables de plantilla per inserir contingut dinàmic."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "La plantilla del cos del certificat és obligatòria"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Text del Peu de Pàgina"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Text opcional que es mostra a la part inferior del certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Variables de Plantilla Disponibles"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Utilitzeu aquestes variables a les vostres plantilles per inserir contingut dinàmic:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Plantilla per defecte"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Utilitzar plantilla per defecte"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Configuració d'Aparença"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Família de Tipus de Lletra"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Mida del Tipus de Lletra"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Color del Text (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Especifiqueu el color del text utilitzant valors RGB (0-255 per a cada component)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Criteris d'Elegibilitat"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Revisions Completades Mínimes"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "El nombre mínim de revisions completades requerides abans que un revisor pugui rebre un certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "El nombre mínim de revisions ha de ser un número més gran o igual a 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Opcions de Verificació"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Incloure codi QR per a la verificació del certificat"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Previsualitzar Certificat"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Tipus d'imatge no vàlid. Si us plau, carregueu un fitxer JPG o PNG."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "La càrrega del fitxer ha fallat. Si us plau, torneu-ho a provar."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Aquesta revisió encara no s'ha completat. Els certificats només estan disponibles per a revisions completades."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "No s'ha proporcionat cap codi de certificat"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Codi de certificat no vàlid. Aquest certificat no s'ha pogut verificar."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "No s'han seleccionat revisors per a la generació massiva de certificats"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Accés denegat. No teniu permís per descarregar aquest certificat."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "No hi ha cap context de revista disponible. Assegureu-vos que accediu des d'una revista vàlida."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "L'accés a la base de dades no està disponible actualment. Si us plau, contacteu amb l'administrador del sistema."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Verificar Certificat"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Introduïu un codi de certificat per verificar-ne l'autenticitat"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Codi del Certificat"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Verificar Certificat"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Certificat Vàlid"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Certificat No Vàlid"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "El codi de certificat que heu introduït no és vàlid o no existeix al nostre sistema."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Codi del Certificat"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Nom del Revisor"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Nom de la Revista"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Data d'Emissió"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Generació Massiva de Certificats"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Genereu certificats per a múltiples revisors alhora. Seleccioneu revisors de la llista a continuació que hagin completat revisions però que encara no tinguin certificats."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Seleccionar Revisors"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "revisions completades"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "No s'han trobat revisors elegibles. Tots els revisors tenen certificats per a les seves revisions completades."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Mantingueu premut Ctrl (Windows/Linux) o Cmd (Mac) per seleccionar múltiples revisors"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Generar Certificats"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Generant certificats..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Si us plau, seleccioneu almenys un revisor"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "certificat/s generat/s amb èxit"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "S'ha produït un error en generar els certificats. Si us plau, torneu-ho a provar."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} certificat/s generat/s amb èxit"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Estadístiques de Certificats"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Resum de la generació i ús de certificats a la vostra revista"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Total de Certificats Emesos"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Total de Descàrregues"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Revisors Únics amb Certificats"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Total de Certificats Emesos"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Total de Descàrregues"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Mitjana de Descàrregues per Certificat"
+

--- a/locale/cs_CZ/locale.po
+++ b/locale/cs_CZ/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Czech\n"
+"Language: cs_CZ\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Plugin Certifikátů Recenzentů"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Umožňuje recenzentům generovat a stahovat personalizované PDF certifikáty uznání po dokončení recenzí."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Certifikát Recenze"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Certifikát Odborného Posouzení"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Váš certifikát je připraven!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Děkujeme za dokončení této recenze. Nyní si můžete stáhnout svůj certifikát uznání."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Váš certifikát bude automaticky vygenerován po kliknutí na tlačítko stažení."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Stáhnout Certifikát"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Nastavení Certifikátů"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Nakonfigurujte šablony certifikátů a kritéria způsobilosti pro recenzenty."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Nastavení Šablony Certifikátu"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Obrázek na Pozadí"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Nahrajte obrázek na pozadí certifikátu (JPG nebo PNG, doporučená velikost: 2100x2970 pixelů pro A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Aktuální obrázek na pozadí"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Text Záhlaví"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Hlavní název zobrazený v horní části certifikátu"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Text záhlaví je povinný"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Šablona Těla Certifikátu"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Hlavní obsah certifikátu. Použijte proměnné šablony pro vložení dynamického obsahu."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Šablona těla certifikátu je povinná"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Text Zápatí"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Volitelný text zobrazený v dolní části certifikátu"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Dostupné Proměnné Šablony"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Použijte tyto proměnné ve svých šablonách pro vložení dynamického obsahu:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Výchozí šablona"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Použít výchozí šablonu"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Nastavení Vzhledu"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Rodina Písma"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Velikost Písma"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Barva Textu (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Určete barvu textu pomocí hodnot RGB (0-255 pro každou složku)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Kritéria Způsobilosti"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Minimální Počet Dokončených Recenzí"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Minimální počet dokončených recenzí požadovaný před tím, než recenzent může obdržet certifikát"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Minimální počet recenzí musí být číslo větší nebo rovno 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Možnosti Ověření"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Zahrnout QR kód pro ověření certifikátu"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Náhled Certifikátu"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Neplatný typ obrázku. Nahrajte prosím soubor JPG nebo PNG."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Nahrání souboru se nezdařilo. Zkuste to prosím znovu."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Tato recenze ještě nebyla dokončena. Certifikáty jsou k dispozici pouze pro dokončené recenze."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Nebyl poskytnut kód certifikátu"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Neplatný kód certifikátu. Tento certifikát nemohl být ověřen."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Nebyli vybráni žádní recenzenti pro hromadné generování certifikátů"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Přístup odepřen. Nemáte oprávnění stáhnout tento certifikát."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Není k dispozici kontext časopisu. Ujistěte se, že přistupujete z platného časopisu."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Přístup k databázi je momentálně nedostupný. Kontaktujte prosím správce systému."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Ověřit Certifikát"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Zadejte kód certifikátu pro ověření jeho pravosti"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Kód Certifikátu"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Ověřit Certifikát"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Platný Certifikát"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Neplatný Certifikát"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Zadaný kód certifikátu není platný nebo v našem systému neexistuje."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Kód Certifikátu"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Jméno Recenzenta"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Název Časopisu"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Datum Vydání"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Hromadné Generování Certifikátů"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Generujte certifikáty pro více recenzentů najednou. Vyberte recenzenty ze seznamu níže, kteří dokončili recenze, ale ještě nemají certifikáty."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Vybrat Recenzenty"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "dokončených recenzí"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Nebyli nalezeni žádní způsobilí recenzenti. Všichni recenzenti mají certifikáty za své dokončené recenze."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Podržte Ctrl (Windows/Linux) nebo Cmd (Mac) pro výběr více recenzentů"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Generovat Certifikáty"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Generování certifikátů..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Vyberte prosím alespoň jednoho recenzenta"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "certifikát/certifikáty úspěšně vygenerovány"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Při generování certifikátů došlo k chybě. Zkuste to prosím znovu."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} certifikát/certifikáty úspěšně vygenerovány"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Statistiky Certifikátů"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Přehled generování a používání certifikátů ve vašem časopisu"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Celkem Vydaných Certifikátů"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Celkem Stažení"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Unikátní Recenzenti s Certifikáty"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Celkem Vydaných Certifikátů"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Celkem Stažení"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Průměrný Počet Stažení na Certifikát"
+

--- a/locale/de_DE/locale.po
+++ b/locale/de_DE/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: German (Germany)\n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Gutachter-Zertifikate Plugin"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Ermöglicht Gutachtern, personalisierte PDF-Zertifikate als Anerkennung nach Abschluss ihrer Begutachtungen zu erstellen und herunterzuladen."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Gutachter-Zertifikat"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Peer-Review-Zertifikat"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Ihr Zertifikat ist fertig!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Vielen Dank für den Abschluss dieser Begutachtung. Sie können jetzt Ihr Anerkennungszertifikat herunterladen."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Ihr Zertifikat wird automatisch erstellt, wenn Sie auf die Download-Schaltfläche klicken."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Zertifikat Herunterladen"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Zertifikat-Einstellungen"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Konfigurieren Sie Zertifikatvorlagen und Zulassungskriterien für Gutachter."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Einstellungen der Zertifikatvorlage"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Hintergrundbild"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Laden Sie ein Hintergrundbild für das Zertifikat hoch (JPG oder PNG, empfohlene Größe: 2100x2970 Pixel für A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Aktuelles Hintergrundbild"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Kopfzeilentext"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Die Hauptüberschrift, die oben auf dem Zertifikat angezeigt wird"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Der Kopfzeilentext ist erforderlich"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Haupttext-Vorlage des Zertifikats"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Der Hauptinhalt des Zertifikats. Verwenden Sie Vorlagenvariablen, um dynamische Inhalte einzufügen."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Die Haupttext-Vorlage des Zertifikats ist erforderlich"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Fußzeilentext"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Optionaler Text, der am unteren Rand des Zertifikats angezeigt wird"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Verfügbare Vorlagenvariablen"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Verwenden Sie diese Variablen in Ihren Vorlagen, um dynamische Inhalte einzufügen:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Standardvorlage"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Standardvorlage verwenden"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Darstellungseinstellungen"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Schriftfamilie"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Schriftgröße"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Textfarbe (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Geben Sie die Textfarbe mit RGB-Werten an (0-255 für jede Komponente)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Zulassungskriterien"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Mindestanzahl Abgeschlossener Begutachtungen"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Die Mindestanzahl abgeschlossener Begutachtungen, die erforderlich ist, bevor ein Gutachter ein Zertifikat erhalten kann"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Die Mindestanzahl der Begutachtungen muss eine Zahl größer oder gleich 1 sein"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Verifizierungsoptionen"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "QR-Code zur Zertifikatsverifizierung einschließen"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Zertifikat-Vorschau"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Ungültiger Bildtyp. Bitte laden Sie eine JPG- oder PNG-Datei hoch."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Datei-Upload fehlgeschlagen. Bitte versuchen Sie es erneut."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Diese Begutachtung wurde noch nicht abgeschlossen. Zertifikate sind nur für abgeschlossene Begutachtungen verfügbar."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Kein Zertifikatscode angegeben"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Ungültiger Zertifikatscode. Dieses Zertifikat konnte nicht verifiziert werden."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Keine Gutachter für die Stapelgenerierung von Zertifikaten ausgewählt"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Zugriff verweigert. Sie haben keine Berechtigung, dieses Zertifikat herunterzuladen."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Kein Zeitschriftenkontext verfügbar. Stellen Sie sicher, dass Sie von einer gültigen Zeitschrift aus zugreifen."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Der Datenbankzugriff ist derzeit nicht verfügbar. Bitte kontaktieren Sie den Systemadministrator."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Zertifikat Verifizieren"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Geben Sie einen Zertifikatscode ein, um dessen Echtheit zu überprüfen"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Zertifikatscode"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Zertifikat Verifizieren"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Zertifikat Gültig"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Zertifikat Ungültig"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Der von Ihnen eingegebene Zertifikatscode ist ungültig oder existiert nicht in unserem System."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Zertifikatscode"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Name des Gutachters"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Name der Zeitschrift"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Ausstellungsdatum"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Stapelgenerierung von Zertifikaten"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Erstellen Sie Zertifikate für mehrere Gutachter gleichzeitig. Wählen Sie Gutachter aus der unten stehenden Liste aus, die Begutachtungen abgeschlossen haben, aber noch keine Zertifikate besitzen."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Gutachter Auswählen"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "abgeschlossene Begutachtungen"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Keine qualifizierten Gutachter gefunden. Alle Gutachter haben Zertifikate für ihre abgeschlossenen Begutachtungen."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Halten Sie Strg (Windows/Linux) oder Cmd (Mac) gedrückt, um mehrere Gutachter auszuwählen"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Zertifikate Erstellen"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Zertifikate werden erstellt..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Bitte wählen Sie mindestens einen Gutachter aus"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "Zertifikat(e) erfolgreich erstellt"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Beim Erstellen der Zertifikate ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} Zertifikat(e) erfolgreich erstellt"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Zertifikat-Statistiken"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Übersicht über die Generierung und Nutzung von Zertifikaten in Ihrer Zeitschrift"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Gesamt Ausgestellte Zertifikate"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Gesamt Downloads"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Eindeutige Gutachter mit Zertifikaten"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Gesamt Ausgestellte Zertifikate"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Gesamt Downloads"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Durchschnittliche Downloads pro Zertifikat"
+

--- a/locale/es_ES/locale.po
+++ b/locale/es_ES/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Spanish (Spain)\n"
+"Language: es_ES\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Plugin de Certificados de Revisores"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Permite a los revisores generar y descargar certificados PDF personalizados de reconocimiento después de completar las revisiones."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Certificado de Revisión"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Certificado de Evaluación por Pares"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "¡Su certificado está listo!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Gracias por completar esta revisión. Ahora puede descargar su certificado de reconocimiento."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Su certificado se generará automáticamente cuando haga clic en el botón de descarga."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Descargar Certificado"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Configuración de Certificados"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Configure las plantillas de certificados y los criterios de elegibilidad para los revisores."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Configuración de Plantilla de Certificado"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Imagen de Fondo"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Suba una imagen de fondo para el certificado (JPG o PNG, tamaño recomendado: 2100x2970 píxeles para A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Imagen de fondo actual"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Texto del Encabezado"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "El encabezado principal que se muestra en la parte superior del certificado"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "El texto del encabezado es obligatorio"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Plantilla del Cuerpo del Certificado"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "El contenido principal del certificado. Use variables de plantilla para insertar contenido dinámico."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "La plantilla del cuerpo del certificado es obligatoria"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Texto del Pie de Página"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Texto opcional que se muestra en la parte inferior del certificado"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Variables de Plantilla Disponibles"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Use estas variables en sus plantillas para insertar contenido dinámico:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Plantilla predeterminada"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Usar plantilla predeterminada"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Configuración de Apariencia"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Familia de Fuente"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Tamaño de Fuente"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Color del Texto (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Especifique el color del texto usando valores RGB (0-255 para cada componente)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Criterios de Elegibilidad"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Revisiones Completadas Mínimas"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "El número mínimo de revisiones completadas requerido antes de que un revisor pueda recibir un certificado"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Las revisiones mínimas deben ser un número mayor o igual a 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Opciones de Verificación"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Incluir código QR para verificación de certificado"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Vista Previa del Certificado"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Tipo de imagen no válido. Por favor, suba un archivo JPG o PNG."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Error al subir el archivo. Por favor, inténtelo de nuevo."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Esta revisión aún no se ha completado. Los certificados solo están disponibles para revisiones completadas."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "No se proporcionó código de certificado"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Código de certificado no válido. Este certificado no pudo ser verificado."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "No se seleccionaron revisores para la generación por lotes de certificados"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Acceso denegado. No tiene permiso para descargar este certificado."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "No hay contexto de revista disponible. Asegúrese de estar accediendo desde una revista válida."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "El acceso a la base de datos no está disponible actualmente. Por favor, contacte al administrador del sistema."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Verificar Certificado"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Ingrese un código de certificado para verificar su autenticidad"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Código de Certificado"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Verificar Certificado"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Certificado Válido"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Certificado No Válido"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "El código de certificado que ingresó no es válido o no existe en nuestro sistema."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Código de Certificado"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Nombre del Revisor"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Nombre de la Revista"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Fecha de Emisión"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Generación por Lotes de Certificados"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Genere certificados para múltiples revisores a la vez. Seleccione revisores de la lista a continuación que hayan completado revisiones pero aún no tengan certificados."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Seleccionar Revisores"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "revisiones completadas"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "No se encontraron revisores elegibles. Todos los revisores tienen certificados para sus revisiones completadas."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Mantenga presionado Ctrl (Windows/Linux) o Cmd (Mac) para seleccionar múltiples revisores"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Generar Certificados"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Generando certificados..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Por favor seleccione al menos un revisor"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "certificado(s) generado(s) exitosamente"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Ocurrió un error al generar los certificados. Por favor, inténtelo de nuevo."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} certificado(s) generado(s) exitosamente"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Estadísticas de Certificados"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Resumen de generación y uso de certificados en su revista"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Total de Certificados Emitidos"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Total de Descargas"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Revisores Únicos con Certificados"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Total de Certificados Emitidos"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Total de Descargas"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Promedio de Descargas por Certificado"
+

--- a/locale/fi_FI/locale.po
+++ b/locale/fi_FI/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Finnish\n"
+"Language: fi_FI\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Arvioitsijatodistuslisäosa"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Mahdollistaa arvioitsijoiden luoda ja ladata henkilökohtaisia PDF-todistuksia tunnustuksena vertaisarvioinnin suorittamisen jälkeen."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Arviointitodistus"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Vertaisarviointitodistus"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Todistuksesi on valmis!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Kiitos arvioinnin suorittamisesta. Voit nyt ladata tunnustustodistuksesi."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Todistuksesi luodaan automaattisesti, kun napsautat lataus-painiketta."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Lataa Todistus"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Todistusasetukset"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Määritä todistuspohjat ja kelpoisuuskriteerit arvioitsijoille."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Todistuspohjan Asetukset"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Taustakuva"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Lataa taustakuva todistukselle (JPG tai PNG, suositeltu koko: 2100x2970 pikseliä A4:lle)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Nykyinen taustakuva"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Otsikkoteksti"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Pääotsikko, joka näytetään todistuksen yläosassa"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Otsikkoteksti vaaditaan"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Todistuksen Rungon Pohja"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Todistuksen pääsisältö. Käytä pohjamuuttujia dynaamisen sisällön lisäämiseen."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Todistuksen rungon pohja vaaditaan"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Alatunnisteteksti"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Valinnainen teksti, joka näytetään todistuksen alaosassa"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Käytettävissä Olevat Pohjamuuttujat"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Käytä näitä muuttujia pohjissasi dynaamisen sisällön lisäämiseen:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Oletuspohja"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Käytä oletuspohjaa"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Ulkoasuasetukset"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Fonttiperhe"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Fonttikoko"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Tekstin Väri (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Määritä tekstin väri käyttämällä RGB-arvoja (0-255 kullekin komponentille)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Kelpoisuuskriteerit"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Vähimmäismäärä Suoritettuja Arviointeja"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Vähimmäismäärä suoritettuja arviointeja, joka vaaditaan ennen kuin arvioitsija voi saada todistuksen"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Vähimmäismäärän arviointeja tulee olla numero, joka on suurempi tai yhtä suuri kuin 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Vahvistusvaihtoehdot"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Sisällytä QR-koodi todistuksen vahvistamiseen"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Esikatsele Todistusta"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Virheellinen kuvatyyppi. Lataa JPG- tai PNG-tiedosto."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Tiedoston lataus epäonnistui. Yritä uudelleen."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Tätä arviointia ei ole vielä suoritettu. Todistukset ovat saatavilla vain suoritetuille arvioinneille."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Todistuskoodia ei annettu"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Virheellinen todistuskoodi. Tätä todistusta ei voitu vahvistaa."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Eräluonnin todistusten luomiseen ei ole valittu arvioitsijoita"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Pääsy evätty. Sinulla ei ole oikeutta ladata tätä todistusta."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Lehden kontekstia ei ole saatavilla. Varmista, että käytät pääsyä kelvollisesta lehdestä."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Tietokantayhteys ei ole tällä hetkellä saatavilla. Ota yhteyttä järjestelmän ylläpitäjään."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Vahvista Todistus"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Anna todistuskoodi sen aitouden vahvistamiseksi"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Todistuskoodi"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Vahvista Todistus"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Kelvollinen Todistus"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Virheellinen Todistus"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Antamasi todistuskoodi ei ole kelvollinen tai sitä ei ole järjestelmässämme."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Todistuskoodi"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Arvioitsijan Nimi"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Lehden Nimi"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Myöntämispäivä"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Todistusten Eräluonti"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Luo todistuksia useille arvioitsijoille kerralla. Valitse arvioitsijat alla olevasta luettelosta, jotka ovat suorittaneet arvioinnit mutta joilla ei vielä ole todistuksia."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Valitse Arvioitsijat"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "suoritettua arviointia"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Kelpoisia arvioitsijoita ei löytynyt. Kaikilla arvioitsijoilla on todistukset suoritetuista arvioinneistaan."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Pidä Ctrl (Windows/Linux) tai Cmd (Mac) painettuna valitaksesi useita arvioitsijoita"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Luo Todistukset"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Luodaan todistuksia..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Valitse vähintään yksi arvioitsija"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "todistus/todistusta luotu onnistuneesti"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Todistusten luonnissa tapahtui virhe. Yritä uudelleen."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} todistus/todistusta luotu onnistuneesti"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Todistustilastot"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Yleiskatsaus todistusten luomisesta ja käytöstä lehdessäsi"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Myönnettyjä Todistuksia Yhteensä"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Latauksia Yhteensä"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Yksilöllisiä Arvioitsijoita Todistuksineen"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Myönnettyjä Todistuksia Yhteensä"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Latauksia Yhteensä"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Keskimääräinen Latausmäärä Todistusta Kohden"
+

--- a/locale/fr_FR/locale.po
+++ b/locale/fr_FR/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: French (France)\n"
+"Language: fr_FR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Plugin de Certificats de Relecteurs"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Permet aux relecteurs de générer et télécharger des certificats PDF personnalisés de reconnaissance après avoir complété les évaluations."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Certificat d'Évaluation"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Certificat d'Évaluation par les Pairs"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Votre certificat est prêt !"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Merci d'avoir complété cette évaluation. Vous pouvez maintenant télécharger votre certificat de reconnaissance."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Votre certificat sera généré automatiquement lorsque vous cliquerez sur le bouton de téléchargement."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Télécharger le Certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Paramètres des Certificats"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Configurez les modèles de certificats et les critères d'éligibilité pour les relecteurs."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Paramètres du Modèle de Certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Image de Fond"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Téléversez une image de fond pour le certificat (JPG ou PNG, taille recommandée : 2100x2970 pixels pour A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Image de fond actuelle"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Texte d'En-tête"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Le titre principal affiché en haut du certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Le texte d'en-tête est requis"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Modèle du Corps du Certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Le contenu principal du certificat. Utilisez les variables de modèle pour insérer du contenu dynamique."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Le modèle du corps du certificat est requis"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Texte du Pied de Page"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Texte optionnel affiché en bas du certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Variables de Modèle Disponibles"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Utilisez ces variables dans vos modèles pour insérer du contenu dynamique :"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Modèle par défaut"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Utiliser le modèle par défaut"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Paramètres d'Apparence"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Famille de Police"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Taille de Police"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Couleur du Texte (RVB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Spécifiez la couleur du texte en utilisant les valeurs RVB (0-255 pour chaque composant)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Critères d'Éligibilité"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Évaluations Complétées Minimales"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Le nombre minimum d'évaluations complétées requis avant qu'un relecteur puisse recevoir un certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Le nombre minimum d'évaluations doit être un nombre supérieur ou égal à 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Options de Vérification"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Inclure un code QR pour la vérification du certificat"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Aperçu du Certificat"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Type d'image invalide. Veuillez téléverser un fichier JPG ou PNG."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Échec du téléversement du fichier. Veuillez réessayer."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Cette évaluation n'est pas encore terminée. Les certificats ne sont disponibles que pour les évaluations complétées."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Aucun code de certificat fourni"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Code de certificat invalide. Ce certificat n'a pas pu être vérifié."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Aucun relecteur sélectionné pour la génération par lots de certificats"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Accès refusé. Vous n'avez pas la permission de télécharger ce certificat."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Aucun contexte de revue disponible. Assurez-vous d'accéder depuis une revue valide."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "L'accès à la base de données est actuellement indisponible. Veuillez contacter l'administrateur système."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Vérifier le Certificat"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Entrez un code de certificat pour vérifier son authenticité"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Code du Certificat"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Vérifier le Certificat"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Certificat Valide"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Certificat Invalide"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Le code de certificat que vous avez entré n'est pas valide ou n'existe pas dans notre système."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Code du Certificat"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Nom du Relecteur"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Nom de la Revue"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Date d'Émission"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Génération par Lots de Certificats"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Générez des certificats pour plusieurs relecteurs à la fois. Sélectionnez les relecteurs dans la liste ci-dessous qui ont complété des évaluations mais n'ont pas encore de certificats."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Sélectionner les Relecteurs"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "évaluations complétées"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Aucun relecteur éligible trouvé. Tous les relecteurs ont des certificats pour leurs évaluations complétées."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Maintenez Ctrl (Windows/Linux) ou Cmd (Mac) pour sélectionner plusieurs relecteurs"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Générer les Certificats"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Génération des certificats..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Veuillez sélectionner au moins un relecteur"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "certificat(s) généré(s) avec succès"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Une erreur s'est produite lors de la génération des certificats. Veuillez réessayer."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} certificat(s) généré(s) avec succès"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Statistiques des Certificats"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Aperçu de la génération et de l'utilisation des certificats dans votre revue"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Total de Certificats Émis"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Total de Téléchargements"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Relecteurs Uniques avec Certificats"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Total de Certificats Émis"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Total de Téléchargements"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Moyenne de Téléchargements par Certificat"
+

--- a/locale/hr_HR/locale.po
+++ b/locale/hr_HR/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Croatian\n"
+"Language: hr_HR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Dodatak za Certifikate Recenzenata"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Omogućuje recenzentima stvaranje i preuzimanje personaliziranih PDF certifikata za priznanje nakon završetka recenzija."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Certifikat o Recenziji"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Certifikat o Stručnoj Recenziji"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Vaš certifikat je spreman!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Hvala što ste dovršili ovu recenziju. Sada možete preuzeti svoj certifikat za priznanje."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Vaš certifikat bit će automatski generiran kada kliknete na gumb za preuzimanje."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Preuzmi Certifikat"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Postavke Certifikata"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Konfigurirajte predloške certifikata i kriterije prihvatljivosti za recenzente."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Postavke Predloška Certifikata"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Pozadinska Slika"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Prenesite pozadinsku sliku za certifikat (JPG ili PNG, preporučena veličina: 2100x2970 piksela za A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Trenutna pozadinska slika"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Tekst Zaglavlja"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Glavni naslov prikazan na vrhu certifikata"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Tekst zaglavlja je obavezan"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Predložak Tijela Certifikata"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Glavni sadržaj certifikata. Koristite varijable predloška za umetanje dinamičkog sadržaja."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Predložak tijela certifikata je obavezan"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Tekst Podnožja"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Opcionalni tekst prikazan na dnu certifikata"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Dostupne Varijable Predloška"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Koristite ove varijable u svojim predlošcima za umetanje dinamičkog sadržaja:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Zadani predložak"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Koristi zadani predložak"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Postavke Izgleda"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Obitelj Fontova"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Veličina Fonta"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Boja Teksta (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Odredite boju teksta koristeći RGB vrijednosti (0-255 za svaku komponentu)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Kriteriji Prihvatljivosti"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Minimalan Broj Završenih Recenzija"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Minimalan broj završenih recenzija potreban prije nego recenzent može primiti certifikat"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Minimalan broj recenzija mora biti broj veći ili jednak 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Opcije Provjere"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Uključi QR kod za provjeru certifikata"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Pregled Certifikata"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Nevažeća vrsta slike. Molimo prenesite JPG ili PNG datoteku."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Prijenos datoteke nije uspio. Molimo pokušajte ponovno."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Ova recenzija još nije završena. Certifikati su dostupni samo za završene recenzije."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Nije dostavljen kod certifikata"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Nevažeći kod certifikata. Ovaj certifikat nije mogao biti provjeren."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Nisu odabrani recenzenti za skupno generiranje certifikata"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Pristup odbijen. Nemate dopuštenje za preuzimanje ovog certifikata."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Nema dostupnog konteksta časopisa. Molimo osigurajte da pristupate iz važećeg časopisa."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Pristup bazi podataka trenutno nije dostupan. Molimo kontaktirajte administratora sustava."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Provjeri Certifikat"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Unesite kod certifikata za provjeru autentičnosti"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Kod Certifikata"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Provjeri Certifikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Važeći Certifikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Nevažeći Certifikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Kod certifikata koji ste unijeli nije važeći ili ne postoji u našem sustavu."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Kod Certifikata"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Ime Recenzenta"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Naziv Časopisa"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Datum Izdavanja"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Skupno Generiranje Certifikata"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Generirajte certifikate za više recenzenata odjednom. Odaberite recenzente s donje liste koji su završili recenzije, ali još nemaju certifikate."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Odaberi Recenzente"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "završenih recenzija"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Nisu pronađeni prihvatljivi recenzenti. Svi recenzenti imaju certifikate za svoje završene recenzije."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Držite Ctrl (Windows/Linux) ili Cmd (Mac) za odabir više recenzenata"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Generiraj Certifikate"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Generiranje certifikata..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Molimo odaberite barem jednog recenzenta"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "certifikat/certifikata uspješno generirano"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Došlo je do pogreške pri generiranju certifikata. Molimo pokušajte ponovno."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} certifikat/certifikata uspješno generirano"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Statistika Certifikata"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Pregled generiranja i korištenja certifikata u vašem časopisu"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Ukupno Izdanih Certifikata"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Ukupno Preuzimanja"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Jedinstvenih Recenzenata s Certifikatima"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Ukupno Izdanih Certifikata"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Ukupno Preuzimanja"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Prosječan Broj Preuzimanja po Certifikatu"
+

--- a/locale/id_ID/locale.po
+++ b/locale/id_ID/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Indonesian\n"
+"Language: id_ID\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Plugin Sertifikat Mitra Bestari"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Memungkinkan mitra bestari untuk menghasilkan dan mengunduh sertifikat PDF penghargaan yang dipersonalisasi setelah menyelesaikan tinjauan."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Sertifikat Tinjauan"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Sertifikat Tinjauan Sejawat"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Sertifikat Anda sudah siap!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Terima kasih telah menyelesaikan tinjauan ini. Anda sekarang dapat mengunduh sertifikat penghargaan Anda."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Sertifikat Anda akan dibuat secara otomatis saat Anda mengklik tombol unduh."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Unduh Sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Pengaturan Sertifikat"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Konfigurasi templat sertifikat dan kriteria kelayakan untuk mitra bestari."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Pengaturan Templat Sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Gambar Latar Belakang"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Unggah gambar latar belakang untuk sertifikat (JPG atau PNG, ukuran yang disarankan: 2100x2970 piksel untuk A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Gambar latar belakang saat ini"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Teks Judul"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Judul utama yang ditampilkan di bagian atas sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Teks judul wajib diisi"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Templat Isi Sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Konten utama sertifikat. Gunakan variabel templat untuk menyisipkan konten dinamis."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Templat isi sertifikat wajib diisi"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Teks Footer"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Teks opsional yang ditampilkan di bagian bawah sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Variabel Templat yang Tersedia"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Gunakan variabel-variabel ini dalam templat Anda untuk menyisipkan konten dinamis:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Templat bawaan"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Gunakan templat bawaan"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Pengaturan Tampilan"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Jenis Huruf"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Ukuran Huruf"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Warna Teks (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Tentukan warna teks menggunakan nilai RGB (0-255 untuk setiap komponen)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Kriteria Kelayakan"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Tinjauan Selesai Minimum"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Jumlah minimum tinjauan yang diselesaikan yang diperlukan sebelum mitra bestari dapat menerima sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Jumlah minimum tinjauan harus berupa angka yang lebih besar atau sama dengan 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Opsi Verifikasi"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Sertakan kode QR untuk verifikasi sertifikat"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Pratinjau Sertifikat"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Jenis gambar tidak valid. Harap unggah file JPG atau PNG."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Pengunggahan file gagal. Harap coba lagi."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Tinjauan ini belum diselesaikan. Sertifikat hanya tersedia untuk tinjauan yang sudah selesai."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Tidak ada kode sertifikat yang diberikan"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Kode sertifikat tidak valid. Sertifikat ini tidak dapat diverifikasi."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Tidak ada mitra bestari yang dipilih untuk pembuatan sertifikat batch"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Akses ditolak. Anda tidak memiliki izin untuk mengunduh sertifikat ini."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Tidak ada konteks jurnal yang tersedia. Pastikan Anda mengakses dari jurnal yang valid."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Akses basis data saat ini tidak tersedia. Harap hubungi administrator sistem."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Verifikasi Sertifikat"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Masukkan kode sertifikat untuk memverifikasi keasliannya"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Kode Sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Verifikasi Sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Sertifikat Valid"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Sertifikat Tidak Valid"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Kode sertifikat yang Anda masukkan tidak valid atau tidak ada dalam sistem kami."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Kode Sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Nama Mitra Bestari"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Nama Jurnal"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Tanggal Penerbitan"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Pembuatan Sertifikat Batch"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Buat sertifikat untuk beberapa mitra bestari sekaligus. Pilih mitra bestari dari daftar di bawah ini yang telah menyelesaikan tinjauan tetapi belum memiliki sertifikat."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Pilih Mitra Bestari"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "tinjauan selesai"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Tidak ada mitra bestari yang memenuhi syarat. Semua mitra bestari memiliki sertifikat untuk tinjauan mereka yang sudah selesai."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Tahan Ctrl (Windows/Linux) atau Cmd (Mac) untuk memilih beberapa mitra bestari"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Buat Sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Membuat sertifikat..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Harap pilih setidaknya satu mitra bestari"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "sertifikat berhasil dibuat"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Terjadi kesalahan saat membuat sertifikat. Harap coba lagi."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} sertifikat berhasil dibuat"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Statistik Sertifikat"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Ikhtisar pembuatan dan penggunaan sertifikat di jurnal Anda"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Total Sertifikat yang Diterbitkan"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Total Unduhan"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Mitra Bestari Unik dengan Sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Total Sertifikat yang Diterbitkan"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Total Unduhan"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Rata-rata Unduhan per Sertifikat"
+

--- a/locale/it_IT/locale.po
+++ b/locale/it_IT/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Italian\n"
+"Language: it_IT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Plugin Certificati Revisori"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Consente ai revisori di generare e scaricare certificati PDF personalizzati di riconoscimento dopo aver completato le revisioni."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Certificato di Revisione"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Certificato di Revisione tra Pari"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Il Suo certificato è pronto!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Grazie per aver completato questa revisione. Ora può scaricare il Suo certificato di riconoscimento."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Il Suo certificato sarà generato automaticamente quando farà clic sul pulsante di download."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Scarica Certificato"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Impostazioni Certificati"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Configura i modelli di certificato e i criteri di idoneità per i revisori."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Impostazioni Modello Certificato"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Immagine di Sfondo"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Carica un'immagine di sfondo per il certificato (JPG o PNG, dimensione consigliata: 2100x2970 pixel per A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Immagine di sfondo attuale"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Testo Intestazione"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Il titolo principale visualizzato nella parte superiore del certificato"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Il testo dell'intestazione è obbligatorio"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Modello Corpo Certificato"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Il contenuto principale del certificato. Usa le variabili del modello per inserire contenuto dinamico."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Il modello del corpo del certificato è obbligatorio"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Testo Piè di Pagina"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Testo facoltativo visualizzato nella parte inferiore del certificato"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Variabili Modello Disponibili"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Usa queste variabili nei tuoi modelli per inserire contenuto dinamico:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Modello predefinito"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Usa modello predefinito"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Impostazioni Aspetto"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Famiglia di Caratteri"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Dimensione Carattere"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Colore Testo (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Specifica il colore del testo utilizzando i valori RGB (0-255 per ciascun componente)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Criteri di Idoneità"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Revisioni Completate Minime"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Il numero minimo di revisioni completate richiesto prima che un revisore possa ricevere un certificato"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Il numero minimo di revisioni deve essere un numero maggiore o uguale a 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Opzioni di Verifica"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Includi codice QR per la verifica del certificato"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Anteprima Certificato"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Tipo di immagine non valido. Si prega di caricare un file JPG o PNG."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Caricamento file non riuscito. Si prega di riprovare."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Questa revisione non è ancora stata completata. I certificati sono disponibili solo per le revisioni completate."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Nessun codice certificato fornito"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Codice certificato non valido. Questo certificato non può essere verificato."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Nessun revisore selezionato per la generazione in batch di certificati"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Accesso negato. Non ha il permesso di scaricare questo certificato."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Nessun contesto di rivista disponibile. Si assicuri di accedere da una rivista valida."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "L'accesso al database non è attualmente disponibile. Si prega di contattare l'amministratore di sistema."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Verifica Certificato"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Inserisci un codice certificato per verificarne l'autenticità"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Codice Certificato"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Verifica Certificato"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Certificato Valido"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Certificato Non Valido"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Il codice certificato inserito non è valido o non esiste nel nostro sistema."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Codice Certificato"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Nome Revisore"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Nome Rivista"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Data di Emissione"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Generazione in Batch di Certificati"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Genera certificati per più revisori contemporaneamente. Seleziona i revisori dall'elenco sottostante che hanno completato le revisioni ma non hanno ancora certificati."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Seleziona Revisori"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "revisioni completate"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Nessun revisore idoneo trovato. Tutti i revisori hanno certificati per le loro revisioni completate."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Tieni premuto Ctrl (Windows/Linux) o Cmd (Mac) per selezionare più revisori"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Genera Certificati"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Generazione certificati in corso..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Si prega di selezionare almeno un revisore"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "certificato/i generato/i con successo"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Si è verificato un errore durante la generazione dei certificati. Si prega di riprovare."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} certificato/i generato/i con successo"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Statistiche Certificati"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Panoramica della generazione e utilizzo dei certificati nella tua rivista"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Totale Certificati Emessi"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Totale Download"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Revisori Unici con Certificati"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Totale Certificati Emessi"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Totale Download"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Media Download per Certificato"
+

--- a/locale/nb_NO/locale.po
+++ b/locale/nb_NO/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Norwegian Bokmål\n"
+"Language: nb_NO\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Plugin for Fagfellesesertifikater"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Lar fagfeller generere og laste ned personaliserte PDF-sertifikater for anerkjennelse etter fullført fagfellevurdering."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Fagfellevurderingssertifikat"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Sertifikat for Fagfellevurdering"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Sertifikatet ditt er klart!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Takk for at du fullførte denne vurderingen. Du kan nå laste ned sertifikatet ditt for anerkjennelse."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Sertifikatet ditt vil bli generert automatisk når du klikker på nedlastingsknappen."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Last ned Sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Sertifikatinnstillinger"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Konfigurer sertifikatmaler og kvalifikasjonskriterier for fagfeller."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Innstillinger for Sertifikatmal"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Bakgrunnsbilde"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Last opp et bakgrunnsbilde for sertifikatet (JPG eller PNG, anbefalt størrelse: 2100x2970 piksler for A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Gjeldende bakgrunnsbilde"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Overskriftstekst"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Hovedtittelen som vises øverst på sertifikatet"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Overskriftstekst er påkrevd"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Mal for Sertifikatinnhold"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Hovedinnholdet i sertifikatet. Bruk malvariabler for å sette inn dynamisk innhold."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Mal for sertifikatinnhold er påkrevd"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Bunntekst"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Valgfri tekst som vises nederst på sertifikatet"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Tilgjengelige Malvariabler"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Bruk disse variablene i malene dine for å sette inn dynamisk innhold:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Standardmal"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Bruk standardmal"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Utseendeinnstillinger"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Skriftfamilie"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Skriftstørrelse"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Tekstfarge (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Spesifiser tekstfargen ved hjelp av RGB-verdier (0-255 for hver komponent)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Kvalifikasjonskriterier"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Minimum Fullførte Vurderinger"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Minimumsantall fullførte vurderinger som kreves før en fagfelle kan motta et sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Minimumsantall vurderinger må være et tall større enn eller lik 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Verifikasjonsalternativer"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Inkluder QR-kode for sertifikatverifisering"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Forhåndsvis Sertifikat"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Ugyldig bildetype. Vennligst last opp en JPG- eller PNG-fil."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Filopplasting mislyktes. Vennligst prøv igjen."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Denne vurderingen er ikke fullført ennå. Sertifikater er kun tilgjengelige for fullførte vurderinger."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Ingen sertifikatkode oppgitt"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Ugyldig sertifikatkode. Dette sertifikatet kunne ikke verifiseres."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Ingen fagfeller valgt for massegenerering av sertifikater"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Tilgang nektet. Du har ikke tillatelse til å laste ned dette sertifikatet."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Ingen tidsskriftkontekst tilgjengelig. Vennligst sørg for at du får tilgang fra et gyldig tidsskrift."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Databasetilgang er for øyeblikket utilgjengelig. Vennligst kontakt systemadministratoren."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Verifiser Sertifikat"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Skriv inn en sertifikatkode for å verifisere ekthet"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Sertifikatkode"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Verifiser Sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Gyldig Sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Ugyldig Sertifikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Sertifikatkoden du skrev inn er ugyldig eller finnes ikke i vårt system."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Sertifikatkode"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Navn på Fagfelle"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Tidsskriftnavn"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Utstedelsesdato"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Massegenerering av Sertifikater"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Generer sertifikater for flere fagfeller samtidig. Velg fagfeller fra listen nedenfor som har fullført vurderinger, men som ennå ikke har sertifikater."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Velg Fagfeller"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "fullførte vurderinger"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Ingen kvalifiserte fagfeller funnet. Alle fagfeller har sertifikater for sine fullførte vurderinger."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Hold Ctrl (Windows/Linux) eller Cmd (Mac) inne for å velge flere fagfeller"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Generer Sertifikater"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Genererer sertifikater..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Vennligst velg minst én fagfelle"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "sertifikat/sertifikater generert"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "En feil oppstod under generering av sertifikater. Vennligst prøv igjen."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} sertifikat/sertifikater generert"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Sertifikatstatistikk"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Oversikt over sertifikatgenerering og -bruk i tidsskriftet ditt"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Totalt Utstedte Sertifikater"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Totale Nedlastinger"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Unike Fagfeller med Sertifikater"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Totalt Utstedte Sertifikater"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Totale Nedlastinger"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Gjennomsnittlige Nedlastinger per Sertifikat"
+

--- a/locale/nl_NL/locale.po
+++ b/locale/nl_NL/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Dutch\n"
+"Language: nl_NL\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Recensentencertificaat Plugin"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Stelt recensenten in staat om gepersonaliseerde PDF-certificaten van erkenning te genereren en te downloaden na het voltooien van beoordelingen."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Beoordelingscertificaat"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Certificaat van Peer Review"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Uw certificaat is klaar!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Bedankt voor het voltooien van deze beoordeling. U kunt nu uw certificaat van erkenning downloaden."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Uw certificaat wordt automatisch gegenereerd wanneer u op de downloadknop klikt."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Certificaat Downloaden"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Certificaatinstellingen"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Configureer certificaatsjablonen en geschiktheidscriteria voor recensenten."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Certificaatsjablooninstellingen"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Achtergrondafbeelding"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Upload een achtergrondafbeelding voor het certificaat (JPG of PNG, aanbevolen grootte: 2100x2970 pixels voor A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Huidige achtergrondafbeelding"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Koptekst"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "De hoofdtitel bovenaan het certificaat"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Koptekst is verplicht"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Certificaat Hoofdtekstsjabloon"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "De hoofdinhoud van het certificaat. Gebruik sjabloonvariabelen om dynamische inhoud in te voegen."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Hoofdtekstsjabloon is verplicht"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Voettekst"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Optionele tekst onderaan het certificaat"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Beschikbare Sjabloonvariabelen"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Gebruik deze variabelen in uw sjablonen om dynamische inhoud in te voegen:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Standaardsjabloon"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Standaardsjabloon gebruiken"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Weergave-instellingen"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Lettertypefamilie"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Lettergrootte"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Tekstkleur (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Specificeer de tekstkleur met RGB-waarden (0-255 voor elk component)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Geschiktheidscriteria"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Minimaal Voltooide Beoordelingen"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Het minimale aantal voltooide beoordelingen voordat een recensent een certificaat kan ontvangen"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Het minimale aantal beoordelingen moet een getal groter dan of gelijk aan 1 zijn"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Verificatie-opties"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "QR-code voor certificaatverificatie opnemen"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Certificaat Voorvertonen"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Ongeldig afbeeldingstype. Upload een JPG- of PNG-bestand."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Bestandsupload mislukt. Probeer het opnieuw."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Deze beoordeling is nog niet voltooid. Certificaten zijn alleen beschikbaar voor voltooide beoordelingen."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Geen certificaatcode opgegeven"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Ongeldige certificaatcode. Dit certificaat kon niet worden geverifieerd."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Geen recensenten geselecteerd voor batch certificaatgeneratie"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Toegang geweigerd. U heeft geen toestemming om dit certificaat te downloaden."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Geen tijdschriftcontext beschikbaar. Zorg ervoor dat u toegang heeft vanuit een geldig tijdschrift."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Databasetoegang is momenteel niet beschikbaar. Neem contact op met de systeembeheerder."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Certificaat Verifiëren"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Voer een certificaatcode in om de authenticiteit te verifiëren"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Certificaatcode"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Certificaat Verifiëren"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Geldig Certificaat"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Ongeldig Certificaat"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "De certificaatcode die u heeft ingevoerd is ongeldig of bestaat niet in ons systeem."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Certificaatcode"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Naam Recensent"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Tijdschriftnaam"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Uitgiftedatum"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Batch Certificaatgeneratie"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Genereer certificaten voor meerdere recensenten tegelijk. Selecteer recensenten uit de onderstaande lijst die beoordelingen hebben voltooid maar nog geen certificaten hebben."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Recensenten Selecteren"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "voltooide beoordelingen"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Geen geschikte recensenten gevonden. Alle recensenten hebben certificaten voor hun voltooide beoordelingen."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Houd Ctrl (Windows/Linux) of Cmd (Mac) ingedrukt om meerdere recensenten te selecteren"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Certificaten Genereren"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Certificaten genereren..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Selecteer ten minste één recensent"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "certificaat/certificaten succesvol gegenereerd"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Er is een fout opgetreden bij het genereren van certificaten. Probeer het opnieuw."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} certificaat/certificaten succesvol gegenereerd"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Certificaatstatistieken"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Overzicht van certificaatgeneratie en -gebruik in uw tijdschrift"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Totaal Uitgegeven Certificaten"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Totaal Downloads"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Unieke Recensenten met Certificaten"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Totaal Uitgegeven Certificaten"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Totaal Downloads"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Gemiddelde Downloads per Certificaat"
+

--- a/locale/pl_PL/locale.po
+++ b/locale/pl_PL/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Polish\n"
+"Language: pl_PL\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Wtyczka Certyfikatów Recenzentów"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Umożliwia recenzentom generowanie i pobieranie spersonalizowanych certyfikatów PDF z podziękowaniem po zakończeniu recenzji."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Certyfikat Recenzji"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Certyfikat Recenzji Naukowej"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Twój certyfikat jest gotowy!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Dziękujemy za ukończenie tej recenzji. Możesz teraz pobrać swój certyfikat z podziękowaniem."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Twój certyfikat zostanie wygenerowany automatycznie po kliknięciu przycisku pobierania."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Pobierz Certyfikat"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Ustawienia Certyfikatów"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Skonfiguruj szablony certyfikatów i kryteria kwalifikacji dla recenzentów."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Ustawienia Szablonu Certyfikatu"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Obraz Tła"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Prześlij obraz tła dla certyfikatu (JPG lub PNG, zalecany rozmiar: 2100x2970 pikseli dla A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Bieżący obraz tła"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Tekst Nagłówka"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Główny tytuł wyświetlany u góry certyfikatu"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Tekst nagłówka jest wymagany"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Szablon Treści Certyfikatu"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Główna treść certyfikatu. Użyj zmiennych szablonu, aby wstawić dynamiczną treść."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Szablon treści certyfikatu jest wymagany"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Tekst Stopki"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Opcjonalny tekst wyświetlany u dołu certyfikatu"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Dostępne Zmienne Szablonu"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Użyj tych zmiennych w swoich szablonach, aby wstawić dynamiczną treść:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Szablon domyślny"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Użyj szablonu domyślnego"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Ustawienia Wyglądu"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Rodzina Czcionki"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Rozmiar Czcionki"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Kolor Tekstu (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Określ kolor tekstu używając wartości RGB (0-255 dla każdego składnika)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Kryteria Kwalifikacji"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Minimalna Liczba Ukończonych Recenzji"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Minimalna liczba ukończonych recenzji wymagana przed otrzymaniem certyfikatu przez recenzenta"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Minimalna liczba recenzji musi być liczbą większą lub równą 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Opcje Weryfikacji"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Dołącz kod QR do weryfikacji certyfikatu"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Podgląd Certyfikatu"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Nieprawidłowy typ obrazu. Proszę przesłać plik JPG lub PNG."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Przesyłanie pliku nie powiodło się. Proszę spróbować ponownie."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Ta recenzja nie została jeszcze ukończona. Certyfikaty są dostępne tylko dla ukończonych recenzji."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Nie podano kodu certyfikatu"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Nieprawidłowy kod certyfikatu. Ten certyfikat nie mógł zostać zweryfikowany."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Nie wybrano recenzentów do zbiorczego generowania certyfikatów"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Odmowa dostępu. Nie masz uprawnień do pobrania tego certyfikatu."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Brak dostępnego kontekstu czasopisma. Upewnij się, że uzyskujesz dostęp z prawidłowego czasopisma."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Dostęp do bazy danych jest obecnie niedostępny. Proszę skontaktować się z administratorem systemu."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Zweryfikuj Certyfikat"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Wprowadź kod certyfikatu, aby zweryfikować jego autentyczność"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Kod Certyfikatu"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Zweryfikuj Certyfikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Certyfikat Ważny"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Certyfikat Nieważny"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Wprowadzony kod certyfikatu jest nieprawidłowy lub nie istnieje w naszym systemie."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Kod Certyfikatu"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Imię i Nazwisko Recenzenta"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Nazwa Czasopisma"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Data Wydania"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Zbiorcze Generowanie Certyfikatów"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Generuj certyfikaty dla wielu recenzentów jednocześnie. Wybierz recenzentów z poniższej listy, którzy ukończyli recenzje, ale nie mają jeszcze certyfikatów."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Wybierz Recenzentów"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "ukończonych recenzji"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Nie znaleziono kwalifikujących się recenzentów. Wszyscy recenzenci mają certyfikaty za swoje ukończone recenzje."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Przytrzymaj Ctrl (Windows/Linux) lub Cmd (Mac), aby wybrać wielu recenzentów"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Generuj Certyfikaty"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Generowanie certyfikatów..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Proszę wybrać co najmniej jednego recenzenta"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "certyfikat(y) wygenerowano pomyślnie"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Wystąpił błąd podczas generowania certyfikatów. Proszę spróbować ponownie."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} certyfikat(y) wygenerowano pomyślnie"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Statystyki Certyfikatów"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Przegląd generowania i wykorzystania certyfikatów w Twoim czasopiśmie"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Łączna Liczba Wydanych Certyfikatów"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Łączna Liczba Pobrań"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Unikalni Recenzenci z Certyfikatami"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Łączna Liczba Wydanych Certyfikatów"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Łączna Liczba Pobrań"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Średnia Liczba Pobrań na Certyfikat"
+

--- a/locale/pt_BR/locale.po
+++ b/locale/pt_BR/locale.po
@@ -1,0 +1,292 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-12-08 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Portuguese (Brazil)\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Plugin de Certificados de Avaliadores"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Permite que avaliadores gerem e baixem certificados personalizados em PDF como reconhecimento após concluírem avaliações."
+
+
+# Certificate labels
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Certificado de Avaliação"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Certificado de Revisão por Pares"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Seu certificado está pronto!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Obrigado por concluir esta avaliação. Agora você pode baixar seu certificado de reconhecimento."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Seu certificado será gerado quando você concluir esta avaliação. Obrigado pela sua valiosa contribuição para nossa revista."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Baixar certificado"
+
+
+# Settings main section
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Configurações de certificados"
+
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Configure os modelos de certificado e os critérios de elegibilidade para avaliadores."
+
+
+# Template settings
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Configurações do modelo de certificado"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Imagem de fundo"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Envie uma imagem de fundo para o certificado (JPG ou PNG, tamanho recomendado: 2100x2970 pixels para A4)."
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Imagem de fundo atual"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Texto do cabeçalho"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Título principal exibido na parte superior do certificado."
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "O texto do cabeçalho é obrigatório."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Modelo do corpo do certificado"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Conteúdo principal do certificado. Use variáveis de modelo para inserir conteúdo dinâmico."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "O modelo do corpo do certificado é obrigatório."
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Texto de rodapé"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Texto opcional exibido na parte inferior do certificado."
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Variáveis de modelo disponíveis"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Use estas variáveis no modelo para inserir automaticamente informações da revista, do avaliador e da avaliação."
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Modelo padrão"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Usar modelo padrão"
+
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Aparência"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Família tipográfica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Tamanho da fonte"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Cor do texto (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Defina a cor do texto usando valores RGB (0–255 para cada componente)."
+
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Critérios de elegibilidade"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Número mínimo de avaliações concluídas"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Número mínimo de avaliações concluídas exigidas para que um avaliador possa receber um certificado."
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "O número mínimo de avaliações deve ser um valor numérico maior ou igual a 1."
+
+
+# Verification / QR
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Verificação do certificado"
+
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Incluir QR code para verificação do certificado"
+
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Pré-visualizar certificado"
+
+
+# Settings errors
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Tipo de imagem inválido. Envie um arquivo JPG ou PNG."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Falha ao enviar o arquivo. Tente novamente."
+
+
+# Runtime errors
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Esta avaliação ainda não foi concluída. Certificados só ficam disponíveis para avaliações concluídas."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Nenhum código de certificado foi informado."
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "O código de certificado informado é inválido."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Nenhum avaliador foi selecionado para geração de certificados."
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Acesso negado. Você não tem permissão para baixar este certificado."
+
+
+# Email notification
+msgid "plugins.generic.reviewerCertificate.email.certificateAvailable.subject"
+msgstr "Seu certificado de avaliação está disponível"
+
+msgid "plugins.generic.reviewerCertificate.email.certificateAvailable.body"
+msgstr ""
+"Prezado(a) {$reviewerName},\n"
+"\n"
+"Seu certificado de avaliação está disponível para download.\n"
+"\n"
+"Obrigado por sua valiosa contribuição para nossa revista.\n"
+"\n"
+"Atenciosamente,\n"
+"Equipe editorial"
+
+
+# Public verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Verificar certificado"
+
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Informe o código do certificado para verificar sua autenticidade."
+
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Código do certificado"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Verificar certificado"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Certificado válido"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Certificado inválido"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "O código de certificado informado é inválido ou não existe em nosso sistema."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Código do certificado"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Nome do avaliador"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Nome da revista"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Data de emissão"
+
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Geração em lote de certificados"
+
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Gere certificados para vários avaliadores de uma só vez."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} certificado(s) gerado(s) com sucesso"
+
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Selecionar avaliadores"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "avaliações concluídas"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Nenhum avaliador elegível encontrado"
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Mantenha pressionada a tecla Ctrl (Cmd no Mac) para selecionar vários avaliadores."
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Gerar certificados"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Gerando certificados..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Selecione pelo menos um avaliador."
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "certificado(s) gerado(s) com sucesso"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Falha ao gerar os certificados."
+
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Estatísticas de certificados"
+
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Veja as estatísticas de emissão de certificados."
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Total de certificados"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Total de downloads"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Avaliadores únicos"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Total de certificados emitidos"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Total de downloads"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Média de downloads por certificado"

--- a/locale/ro_RO/locale.po
+++ b/locale/ro_RO/locale.po
@@ -1,0 +1,282 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Romanian\n"
+"Language: ro_RO\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Plugin Certificate Recenzori"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Permite recenzorilor să genereze și să descarce certificate PDF personalizate de recunoaștere după finalizarea recenziilor."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Certificat de Recenzie"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr ""
+"Certificat de Recenzie Colegi\n"
+"\n"
+"ală"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Certificatul dumneavoastră este gata!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Vă mulțumim pentru finalizarea acestei recenzii. Acum puteți descărca certificatul dumneavoastră de recunoaștere."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Certificatul dumneavoastră va fi generat automat când veți apăsa butonul de descărcare."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Descarcă Certificatul"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Setări Certificate"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Configurați șabloanele de certificate și criteriile de eligibilitate pentru recenzori."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Setări Șablon Certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Imagine de Fundal"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Încărcați o imagine de fundal pentru certificat (JPG sau PNG, dimensiune recomandată: 2100x2970 pixeli pentru A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Imaginea de fundal curentă"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Text Antet"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Titlul principal afișat în partea de sus a certificatului"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Textul antetului este obligatoriu"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Șablon Corp Certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Conținutul principal al certificatului. Utilizați variabilele șablonului pentru a insera conținut dinamic."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Șablonul corpului certificatului este obligatoriu"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Text Subsol"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Text opțional afișat în partea de jos a certificatului"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Variabile Șablon Disponibile"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Utilizați aceste variabile în șabloanele dumneavoastră pentru a insera conținut dinamic:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Șablon implicit"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Utilizați șablonul implicit"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Setări Aspect"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Familie Font"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Dimensiune Font"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Culoare Text (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Specificați culoarea textului utilizând valori RGB (0-255 pentru fiecare componentă)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Criterii de Eligibilitate"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Recenzii Finalizate Minime"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Numărul minim de recenzii finalizate necesar înainte ca un recenzor să poată primi un certificat"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Numărul minim de recenzii trebuie să fie un număr mai mare sau egal cu 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Opțiuni de Verificare"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Includeți codul QR pentru verificarea certificatului"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Previzualizare Certificat"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Tip de imagine nevalid. Vă rugăm să încărcați un fișier JPG sau PNG."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Încărcarea fișierului a eșuat. Vă rugăm să încercați din nou."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Această recenzie nu a fost încă finalizată. Certificatele sunt disponibile doar pentru recenzii finalizate."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Nu a fost furnizat niciun cod de certificat"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Cod de certificat nevalid. Acest certificat nu a putut fi verificat."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Nu au fost selectați recenzori pentru generarea în lot a certificatelor"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Acces refuzat. Nu aveți permisiunea de a descărca acest certificat."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Nu există un context de revistă disponibil. Vă rugăm să vă asigurați că accesați dintr-o revistă validă."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Accesul la baza de date este momentan indisponibil. Vă rugăm să contactați administratorul de sistem."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Verificare Certificat"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Introduceți un cod de certificat pentru a-i verifica autenticitatea"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Cod Certificat"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Verificați Certificatul"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Certificat Valid"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Certificat Nevalid"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Codul de certificat pe care l-ați introdus nu este valid sau nu există în sistemul nostru."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Cod Certificat"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Nume Recenzor"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Nume Revistă"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Data Emiterii"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Generare în Lot a Certificatelor"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Generați certificate pentru mai mulți recenzori simultan. Selectați recenzorii din lista de mai jos care au finalizat recenzii dar nu au încă certificate."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Selectați Recenzori"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "recenzii finalizate"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Nu au fost găsiți recenzori eligibili. Toți recenzorii au certificate pentru recenziile lor finalizate."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Țineți apăsat Ctrl (Windows/Linux) sau Cmd (Mac) pentru a selecta mai mulți recenzori"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Generați Certificate"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Se generează certificatele..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Vă rugăm să selectați cel puțin un recenzor"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "certificat/certificate generate cu succes"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "A apărut o eroare la generarea certificatelor. Vă rugăm să încercați din nou."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} certificat/certificate generate cu succes"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Statistici Certificate"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Prezentare generală a generării și utilizării certificatelor în revista dumneavoastră"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Total Certificate Emise"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Total Descărcări"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Recenzori Unici cu Certificate"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Total Certificate Emise"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Total Descărcări"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Medie Descărcări per Certificat"
+

--- a/locale/ru_RU/locale.po
+++ b/locale/ru_RU/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Russian\n"
+"Language: ru_RU\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Плагин сертификатов рецензентов"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Позволяет рецензентам генерировать и загружать персонализированные PDF-сертификаты признания после завершения рецензирования."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Сертификат рецензента"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Сертификат экспертной оценки"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Ваш сертификат готов!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Благодарим за завершение рецензирования. Теперь вы можете загрузить свой сертификат признания."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Ваш сертификат будет сгенерирован автоматически при нажатии кнопки загрузки."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Загрузить сертификат"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Настройки сертификатов"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Настройте шаблоны сертификатов и критерии приемлемости для рецензентов."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Настройки шаблона сертификата"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Фоновое изображение"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Загрузите фоновое изображение для сертификата (JPG или PNG, рекомендуемый размер: 2100x2970 пикселей для A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Текущее фоновое изображение"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Текст заголовка"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Основной заголовок, отображаемый в верхней части сертификата"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Текст заголовка обязателен"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Шаблон тела сертификата"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Основное содержимое сертификата. Используйте переменные шаблона для вставки динамического содержимого."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Шаблон тела сертификата обязателен"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Текст нижнего колонтитула"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Необязательный текст, отображаемый в нижней части сертификата"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Доступные переменные шаблона"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Используйте эти переменные в своих шаблонах для вставки динамического содержимого:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Стандартный шаблон"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Использовать стандартный шаблон"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Настройки внешнего вида"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Семейство шрифтов"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Размер шрифта"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Цвет текста (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Укажите цвет текста, используя значения RGB (0-255 для каждого компонента)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Критерии приемлемости"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Минимальное количество завершенных рецензий"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Минимальное количество завершенных рецензий, необходимое перед тем, как рецензент сможет получить сертификат"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Минимальное количество рецензий должно быть числом, большим или равным 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Параметры проверки"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Включить QR-код для проверки сертификата"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Предварительный просмотр сертификата"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Недопустимый тип изображения. Пожалуйста, загрузите файл JPG или PNG."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Ошибка загрузки файла. Пожалуйста, попробуйте еще раз."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Это рецензирование еще не завершено. Сертификаты доступны только для завершенных рецензий."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Код сертификата не предоставлен"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Недействительный код сертификата. Этот сертификат не может быть проверен."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Не выбрано ни одного рецензента для пакетной генерации сертификатов"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Доступ запрещен. У вас нет разрешения на загрузку этого сертификата."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Контекст журнала недоступен. Убедитесь, что вы получаете доступ из действительного журнала."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Доступ к базе данных в настоящее время недоступен. Обратитесь к системному администратору."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Проверить сертификат"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Введите код сертификата для проверки его подлинности"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Код сертификата"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Проверить сертификат"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Сертификат действителен"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Сертификат недействителен"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Введенный вами код сертификата недействителен или не существует в нашей системе."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Код сертификата"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Имя рецензента"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Название журнала"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Дата выдачи"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Пакетная генерация сертификатов"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Генерируйте сертификаты для нескольких рецензентов одновременно. Выберите рецензентов из списка ниже, которые завершили рецензирование, но еще не имеют сертификатов."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Выберите рецензентов"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "завершенных рецензий"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Приемлемых рецензентов не найдено. Все рецензенты имеют сертификаты для своих завершенных рецензий."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Удерживайте Ctrl (Windows/Linux) или Cmd (Mac) для выбора нескольких рецензентов"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Генерировать сертификаты"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Генерация сертификатов..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Пожалуйста, выберите хотя бы одного рецензента"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "сертификат(ов) успешно сгенерировано"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Произошла ошибка при генерации сертификатов. Пожалуйста, попробуйте еще раз."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} сертификат(ов) успешно сгенерировано"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Статистика сертификатов"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Обзор генерации и использования сертификатов в вашем журнале"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Всего выдано сертификатов"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Всего загрузок"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Уникальных рецензентов с сертификатами"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Всего выдано сертификатов"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Всего загрузок"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Среднее количество загрузок на сертификат"
+

--- a/locale/sv_SE/locale.po
+++ b/locale/sv_SE/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Swedish\n"
+"Language: sv_SE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Plugin för Granskarcertifikat"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Gör det möjligt för granskare att generera och ladda ner personliga PDF-certifikat för erkännande efter slutförda granskningar."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Granskningscertifikat"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Certifikat för Kollegial Granskning"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Ditt certifikat är klart!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Tack för att du slutförde denna granskning. Du kan nu ladda ner ditt certifikat för erkännande."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Ditt certifikat kommer att genereras automatiskt när du klickar på nedladdningsknappen."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Ladda ner Certifikat"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Certifikatinställningar"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Konfigurera certifikatmallar och behörighetskriterier för granskare."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Inställningar för Certifikatmall"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Bakgrundsbild"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Ladda upp en bakgrundsbild för certifikatet (JPG eller PNG, rekommenderad storlek: 2100x2970 pixlar för A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Nuvarande bakgrundsbild"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Rubriktext"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Huvudrubriken som visas högst upp på certifikatet"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Rubriktext krävs"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Mall för Certifikatinnehåll"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Huvudinnehållet i certifikatet. Använd mallvariabler för att infoga dynamiskt innehåll."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Mall för certifikatinnehåll krävs"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Sidfotstext"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Valfri text som visas längst ner på certifikatet"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Tillgängliga Mallvariabler"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Använd dessa variabler i dina mallar för att infoga dynamiskt innehåll:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Standardmall"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Använd standardmall"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Utseendeinställningar"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Typsnittsfamilj"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Teckenstorlek"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Textfärg (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Ange textfärg med RGB-värden (0-255 för varje komponent)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Behörighetskriterier"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Minsta Antal Slutförda Granskningar"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Minsta antal slutförda granskningar som krävs innan en granskare kan få ett certifikat"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Minsta antal granskningar måste vara ett tal större än eller lika med 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Verifieringsalternativ"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Inkludera QR-kod för certifikatverifiering"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Förhandsgranska Certifikat"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Ogiltig bildtyp. Vänligen ladda upp en JPG- eller PNG-fil."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Filuppladdning misslyckades. Vänligen försök igen."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Denna granskning är inte slutförd ännu. Certifikat är endast tillgängliga för slutförda granskningar."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Ingen certifikatkod angiven"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Ogiltig certifikatkod. Detta certifikat kunde inte verifieras."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Inga granskare valda för batchgenerering av certifikat"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Åtkomst nekad. Du har inte behörighet att ladda ner detta certifikat."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Ingen tidskriftskontext tillgänglig. Vänligen se till att du kommer åt från en giltig tidskrift."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Databasåtkomst är för närvarande otillgänglig. Vänligen kontakta systemadministratören."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Verifiera Certifikat"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Ange en certifikatkod för att verifiera äktheten"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Certifikatkod"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Verifiera Certifikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Giltigt Certifikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Ogiltigt Certifikat"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Certifikatkoden du angav är ogiltig eller finns inte i vårt system."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Certifikatkod"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Granskarens Namn"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Tidskriftens Namn"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Utfärdandedatum"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Batchgenerering av Certifikat"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Generera certifikat för flera granskare samtidigt. Välj granskare från listan nedan som har slutfört granskningar men ännu inte har certifikat."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Välj Granskare"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "slutförda granskningar"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Inga behöriga granskare hittades. Alla granskare har certifikat för sina slutförda granskningar."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Håll Ctrl (Windows/Linux) eller Cmd (Mac) nedtryckt för att välja flera granskare"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Generera Certifikat"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Genererar certifikat..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Vänligen välj minst en granskare"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "certifikat genererade framgångsrikt"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Ett fel uppstod vid generering av certifikat. Vänligen försök igen."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} certifikat genererade framgångsrikt"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Certifikatstatistik"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Översikt över certifikatgenerering och användning i din tidskrift"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Totalt Utfärdade Certifikat"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Totalt Antal Nedladdningar"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Unika Granskare med Certifikat"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Totalt Utfärdade Certifikat"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Totalt Antal Nedladdningar"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Genomsnittligt Antal Nedladdningar per Certifikat"
+

--- a/locale/tr_TR/locale.po
+++ b/locale/tr_TR/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Turkish\n"
+"Language: tr_TR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Hakem Sertifikası Eklentisi"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Hakemlerin değerlendirmeleri tamamladıktan sonra kişiselleştirilmiş PDF takdir sertifikaları oluşturmalarına ve indirmelerine olanak tanır."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Değerlendirme Sertifikası"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Hakem Değerlendirmesi Sertifikası"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Sertifikanız hazır!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Bu değerlendirmeyi tamamladığınız için teşekkür ederiz. Artık takdir sertifikanızı indirebilirsiniz."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "İndirme düğmesine tıkladığınızda sertifikanız otomatik olarak oluşturulacaktır."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Sertifikayı İndir"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Sertifika Ayarları"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Hakemler için sertifika şablonlarını ve uygunluk kriterlerini yapılandırın."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Sertifika Şablonu Ayarları"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Arka Plan Resmi"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Sertifika için bir arka plan resmi yükleyin (JPG veya PNG, önerilen boyut: A4 için 2100x2970 piksel)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Mevcut arka plan resmi"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Başlık Metni"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Sertifikanın üst kısmında görüntülenen ana başlık"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Başlık metni gereklidir"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Sertifika Gövde Şablonu"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Sertifikanın ana içeriği. Dinamik içerik eklemek için şablon değişkenlerini kullanın."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Sertifika gövde şablonu gereklidir"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Alt Bilgi Metni"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Sertifikanın alt kısmında görüntülenen isteğe bağlı metin"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Kullanılabilir Şablon Değişkenleri"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Dinamik içerik eklemek için şablonlarınızda bu değişkenleri kullanın:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Varsayılan şablon"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Varsayılan şablonu kullan"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Görünüm Ayarları"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Yazı Tipi Ailesi"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Yazı Tipi Boyutu"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Metin Rengi (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "RGB değerlerini kullanarak metin rengini belirtin (her bileşen için 0-255)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Uygunluk Kriterleri"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Minimum Tamamlanmış Değerlendirme"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Bir hakemin sertifika alabilmesi için gereken minimum tamamlanmış değerlendirme sayısı"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Minimum değerlendirme sayısı 1'den büyük veya eşit bir sayı olmalıdır"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Doğrulama Seçenekleri"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Sertifika doğrulaması için QR kodu ekle"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Sertifikayı Önizle"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Geçersiz resim türü. Lütfen bir JPG veya PNG dosyası yükleyin."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Dosya yükleme başarısız oldu. Lütfen tekrar deneyin."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Bu değerlendirme henüz tamamlanmadı. Sertifikalar yalnızca tamamlanmış değerlendirmeler için kullanılabilir."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Sertifika kodu sağlanmadı"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Geçersiz sertifika kodu. Bu sertifika doğrulanamadı."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Toplu sertifika oluşturma için hakem seçilmedi"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Erişim reddedildi. Bu sertifikayı indirme yetkiniz yok."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Dergi bağlamı mevcut değil. Lütfen geçerli bir dergiden eriştiğinizden emin olun."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Veritabanı erişimi şu anda kullanılamıyor. Lütfen sistem yöneticisiyle iletişime geçin."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Sertifikayı Doğrula"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Özgünlüğünü doğrulamak için bir sertifika kodu girin"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Sertifika Kodu"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Sertifikayı Doğrula"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Geçerli Sertifika"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Geçersiz Sertifika"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Girdiğiniz sertifika kodu geçersiz veya sistemimizde mevcut değil."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Sertifika Kodu"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Hakem Adı"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Dergi Adı"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Verilme Tarihi"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Toplu Sertifika Oluşturma"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Birden fazla hakem için aynı anda sertifika oluşturun. Değerlendirmeleri tamamlamış ancak henüz sertifikaları olmayan hakemleri aşağıdaki listeden seçin."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Hakemleri Seç"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "tamamlanmış değerlendirme"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Uygun hakem bulunamadı. Tüm hakemlerin tamamlanmış değerlendirmeleri için sertifikaları var."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Birden fazla hakem seçmek için Ctrl (Windows/Linux) veya Cmd (Mac) tuşunu basılı tutun"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Sertifikaları Oluştur"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Sertifikalar oluşturuluyor..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Lütfen en az bir hakem seçin"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "sertifika başarıyla oluşturuldu"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Sertifikalar oluşturulurken bir hata oluştu. Lütfen tekrar deneyin."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} sertifika başarıyla oluşturuldu"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Sertifika İstatistikleri"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Derginizdeki sertifika oluşturma ve kullanım genel bakışı"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Toplam Verilen Sertifika"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Toplam İndirme"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Sertifikalı Benzersiz Hakem"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Toplam Verilen Sertifika"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Toplam İndirme"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Sertifika Başına Ortalama İndirme"
+

--- a/locale/uk_UA/locale.po
+++ b/locale/uk_UA/locale.po
@@ -1,0 +1,279 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: reviewerCertificate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-03 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Ukrainian\n"
+"Language: uk_UA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.displayName"
+msgstr "Плагін сертифікатів рецензентів"
+
+msgid "plugins.generic.reviewerCertificate.description"
+msgstr "Дозволяє рецензентам генерувати та завантажувати персоналізовані PDF-сертифікати визнання після завершення рецензування."
+
+# Certificate titles
+msgid "plugins.generic.reviewerCertificate.certificateTitle"
+msgstr "Сертифікат рецензента"
+
+msgid "plugins.generic.reviewerCertificate.certificateSubject"
+msgstr "Сертифікат експертної оцінки"
+
+# Dashboard messages
+msgid "plugins.generic.reviewerCertificate.certificateAvailable"
+msgstr "Ваш сертифікат готовий!"
+
+msgid "plugins.generic.reviewerCertificate.certificateAvailableDescription"
+msgstr "Дякуємо за завершення рецензування. Тепер ви можете завантажити свій сертифікат визнання."
+
+msgid "plugins.generic.reviewerCertificate.certificateWillBeGenerated"
+msgstr "Ваш сертифікат буде згенеровано автоматично при натисканні кнопки завантаження."
+
+msgid "plugins.generic.reviewerCertificate.downloadCertificate"
+msgstr "Завантажити сертифікат"
+
+msgid "plugins.generic.reviewerCertificate.settings"
+msgstr "Налаштування сертифікатів"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.description"
+msgstr "Налаштуйте шаблони сертифікатів та критерії прийнятності для рецензентів."
+
+msgid "plugins.generic.reviewerCertificate.settings.templateSettings"
+msgstr "Налаштування шаблону сертифіката"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImage"
+msgstr "Фонове зображення"
+
+msgid "plugins.generic.reviewerCertificate.settings.backgroundImageDescription"
+msgstr "Завантажте фонове зображення для сертифіката (JPG або PNG, рекомендований розмір: 2100x2970 пікселів для A4)"
+
+msgid "plugins.generic.reviewerCertificate.settings.currentImage"
+msgstr "Поточне фонове зображення"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerText"
+msgstr "Текст заголовка"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextDescription"
+msgstr "Основний заголовок, що відображається у верхній частині сертифіката"
+
+msgid "plugins.generic.reviewerCertificate.settings.headerTextRequired"
+msgstr "Текст заголовка є обов'язковим"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplate"
+msgstr "Шаблон тіла сертифіката"
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateDescription"
+msgstr "Основний вміст сертифіката. Використовуйте змінні шаблону для вставки динамічного вмісту."
+
+msgid "plugins.generic.reviewerCertificate.settings.bodyTemplateRequired"
+msgstr "Шаблон тіла сертифіката є обов'язковим"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerText"
+msgstr "Текст нижнього колонтитула"
+
+msgid "plugins.generic.reviewerCertificate.settings.footerTextDescription"
+msgstr "Необов'язковий текст, що відображається у нижній частині сертифіката"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariables"
+msgstr "Доступні змінні шаблону"
+
+msgid "plugins.generic.reviewerCertificate.settings.availableVariablesDescription"
+msgstr "Використовуйте ці змінні у своїх шаблонах для вставки динамічного вмісту:"
+
+msgid "plugins.generic.reviewerCertificate.settings.defaultTemplate"
+msgstr "Типовий шаблон"
+
+msgid "plugins.generic.reviewerCertificate.settings.useDefaultTemplate"
+msgstr "Використовувати типовий шаблон"
+
+# Appearance settings
+msgid "plugins.generic.reviewerCertificate.settings.appearance"
+msgstr "Налаштування вигляду"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontFamily"
+msgstr "Сімейство шрифтів"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.helvetica"
+msgstr "Helvetica"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.times"
+msgstr "Times New Roman"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.courier"
+msgstr "Courier"
+
+msgid "plugins.generic.reviewerCertificate.settings.font.dejavusans"
+msgstr "DejaVu Sans"
+
+msgid "plugins.generic.reviewerCertificate.settings.fontSize"
+msgstr "Розмір шрифту"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColor"
+msgstr "Колір тексту (RGB)"
+
+msgid "plugins.generic.reviewerCertificate.settings.textColorDescription"
+msgstr "Вкажіть колір тексту, використовуючи значення RGB (0-255 для кожного компонента)"
+
+# Eligibility settings
+msgid "plugins.generic.reviewerCertificate.settings.eligibility"
+msgstr "Критерії прийнятності"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviews"
+msgstr "Мінімальна кількість завершених рецензій"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsDescription"
+msgstr "Мінімальна кількість завершених рецензій, необхідна перед тим, як рецензент може отримати сертифікат"
+
+msgid "plugins.generic.reviewerCertificate.settings.minimumReviewsInvalid"
+msgstr "Мінімальна кількість рецензій має бути числом, більшим або рівним 1"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.verification"
+msgstr "Параметри перевірки"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.includeQRCode"
+msgstr "Включити QR-код для перевірки сертифіката"
+
+# Verification settings
+msgid "plugins.generic.reviewerCertificate.settings.previewCertificate"
+msgstr "Переглянути сертифікат"
+
+# Settings form
+msgid "plugins.generic.reviewerCertificate.settings.invalidImageType"
+msgstr "Недійсний тип зображення. Будь ласка, завантажте файл JPG або PNG."
+
+msgid "plugins.generic.reviewerCertificate.settings.uploadFailed"
+msgstr "Помилка завантаження файлу. Будь ласка, спробуйте ще раз."
+
+# Error messages
+msgid "plugins.generic.reviewerCertificate.error.reviewNotCompleted"
+msgstr "Це рецензування ще не завершено. Сертифікати доступні лише для завершених рецензій."
+
+msgid "plugins.generic.reviewerCertificate.error.noCertificateCode"
+msgstr "Код сертифіката не надано"
+
+msgid "plugins.generic.reviewerCertificate.error.invalidCertificate"
+msgstr "Недійсний код сертифіката. Цей сертифікат не може бути перевірений."
+
+msgid "plugins.generic.reviewerCertificate.error.noReviewersSelected"
+msgstr "Не вибрано жодного рецензента для пакетного генерування сертифікатів"
+
+msgid "plugins.generic.reviewerCertificate.error.accessDenied"
+msgstr "Доступ заборонено. У вас немає дозволу на завантаження цього сертифіката."
+
+msgid "plugins.generic.reviewerCertificate.error.noContext"
+msgstr "Контекст журналу недоступний. Переконайтеся, що ви отримуєте доступ з дійсного журналу."
+
+msgid "plugins.generic.reviewerCertificate.error.daoNotAvailable"
+msgstr "Доступ до бази даних наразі недоступний. Зверніться до системного адміністратора."
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.title"
+msgstr "Перевірити сертифікат"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.verify.description"
+msgstr "Введіть код сертифіката для перевірки його автентичності"
+
+# Verification page
+msgid "plugins.generic.reviewerCertificate.verify.code"
+msgstr "Код сертифіката"
+
+msgid "plugins.generic.reviewerCertificate.verify.button"
+msgstr "Перевірити сертифікат"
+
+msgid "plugins.generic.reviewerCertificate.verify.valid"
+msgstr "Сертифікат дійсний"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalid"
+msgstr "Сертифікат недійсний"
+
+msgid "plugins.generic.reviewerCertificate.verify.invalidDescription"
+msgstr "Введений вами код сертифіката недійсний або не існує в нашій системі."
+
+msgid "plugins.generic.reviewerCertificate.verify.certificateCode"
+msgstr "Код сертифіката"
+
+msgid "plugins.generic.reviewerCertificate.verify.reviewerName"
+msgstr "Ім'я рецензента"
+
+msgid "plugins.generic.reviewerCertificate.verify.journalName"
+msgstr "Назва журналу"
+
+msgid "plugins.generic.reviewerCertificate.verify.dateIssued"
+msgstr "Дата видачі"
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.title"
+msgstr "Пакетне генерування сертифікатів"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.batch.description"
+msgstr "Генеруйте сертифікати для кількох рецензентів одночасно. Виберіть рецензентів зі списку нижче, які завершили рецензування, але ще не мають сертифікатів."
+
+# Batch generation
+msgid "plugins.generic.reviewerCertificate.batch.selectReviewers"
+msgstr "Виберіть рецензентів"
+
+msgid "plugins.generic.reviewerCertificate.batch.completedReviews"
+msgstr "завершених рецензій"
+
+msgid "plugins.generic.reviewerCertificate.batch.noEligibleReviewers"
+msgstr "Прийнятних рецензентів не знайдено. Усі рецензенти мають сертифікати для своїх завершених рецензій."
+
+msgid "plugins.generic.reviewerCertificate.batch.selectMultipleHint"
+msgstr "Утримуйте Ctrl (Windows/Linux) або Cmd (Mac) для вибору кількох рецензентів"
+
+msgid "plugins.generic.reviewerCertificate.batch.generate"
+msgstr "Генерувати сертифікати"
+
+msgid "plugins.generic.reviewerCertificate.batch.generating"
+msgstr "Генерування сертифікатів..."
+
+msgid "plugins.generic.reviewerCertificate.batch.noSelection"
+msgstr "Будь ласка, виберіть принаймні одного рецензента"
+
+msgid "plugins.generic.reviewerCertificate.batch.certificatesGenerated"
+msgstr "сертифікат(и/ів) успішно згенеровано"
+
+msgid "plugins.generic.reviewerCertificate.batch.error"
+msgstr "Виникла помилка під час генерування сертифікатів. Будь ласка, спробуйте ще раз."
+
+msgid "plugins.generic.reviewerCertificate.batch.generated"
+msgstr "{$count} сертифікат(и/ів) успішно згенеровано"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.title"
+msgstr "Статистика сертифікатів"
+
+# Plugin metadata
+msgid "plugins.generic.reviewerCertificate.statistics.description"
+msgstr "Огляд генерування та використання сертифікатів у вашому журналі"
+
+# Statistics
+msgid "plugins.generic.reviewerCertificate.statistics.totalCertificates"
+msgstr "Всього видано сертифікатів"
+
+msgid "plugins.generic.reviewerCertificate.statistics.totalDownloads"
+msgstr "Всього завантажень"
+
+msgid "plugins.generic.reviewerCertificate.statistics.uniqueReviewers"
+msgstr "Унікальних рецензентів із сертифікатами"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalIssued"
+msgstr "Всього видано сертифікатів"
+
+msgid "plugins.generic.reviewerCertificate.stats.totalDownloads"
+msgstr "Всього завантажень"
+
+msgid "plugins.generic.reviewerCertificate.stats.averageDownloads"
+msgstr "Середня кількість завантажень на сертифікат"
+

--- a/templates/verify.tpl
+++ b/templates/verify.tpl
@@ -22,7 +22,7 @@
 							<p><strong>{translate key="plugins.generic.reviewerCertificate.verify.certificateCode"}:</strong> {$certificateCode}</p>
 							<p><strong>{translate key="plugins.generic.reviewerCertificate.verify.reviewerName"}:</strong> {$reviewerName}</p>
 							<p><strong>{translate key="plugins.generic.reviewerCertificate.verify.journalName"}:</strong> {$journalName}</p>
-							<p><strong>{translate key="plugins.generic.reviewerCertificate.verify.dateIssued"}:</strong> {$dateIssued|date_format:"%B %e, %Y"}</p>
+							<p><strong>{translate key="plugins.generic.reviewerCertificate.verify.dateIssued"}:</strong> {$dateIssued}</p>
 						</div>
 					</div>
 				{else}

--- a/version.xml
+++ b/version.xml
@@ -14,8 +14,8 @@
 <version>
 	<application>reviewerCertificate</application>
 	<type>plugins.generic</type>
-	<release>1.0.3.0</release>
-	<date>2025-11-24</date>
+	<release>1.0.5.0</release>
+	<date>2025-01-03</date>
 	<lazy-load>1</lazy-load>
 	<class>ReviewerCertificatePlugin</class>
 	<sitewide>0</sitewide>


### PR DESCRIPTION
## Summary

- **Fixed**: Date format display on certificate verification page showing `%B %e, %Y` instead of formatted date
- **Fixed**: PHP 8.1+ compatibility - replaced deprecated `strftime()` with `date()` function
- **Fixed**: Missing return statement after error in download handler causing potential memory issues
- **Added**: `.po` locale files for all 20 languages (OJS 3.5 compatibility)
- **Added**: Brazilian Portuguese translation (community contribution by Pedro Felipe Rocha)

## Issues Addressed

This PR addresses issues reported by Olha P. Pinchuk on OJS installation at dev.journal.iitta.gov.ua:
1. Date format error showing `%463 %e, %2025` on verification page (photo2.jpg)
2. Memory exhaustion in CertificateDAO.inc.php (photo1.jpg)

Also addresses community feedback from Pedro Felipe Rocha on PKP Community Forum regarding OJS 3.5 locale compatibility.

## Changes

### Date Format Fix
- `controllers/CertificateHandler.inc.php`: Format date in PHP using `date('F j, Y')` before passing to template
- `templates/verify.tpl`: Removed deprecated `date_format` Smarty modifier

### Memory Fix
- `controllers/CertificateHandler.inc.php`: Added missing `return` after `fatalError()` in download() method

### Locale Files
- Added `.po` locale files for all 20 supported languages
- OJS 3.5 requires `.po` format (not `.xml`) for translations to work

## Test plan

- [ ] Verify certificate verification page displays date correctly (e.g., "January 3, 2025")
- [ ] Test certificate download for incomplete reviews - should show error and not continue execution
- [ ] Test translations work correctly in OJS 3.5 installations
- [ ] Run locale validation tests: `php vendor/bin/phpunit tests/Locale/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)